### PR TITLE
Renew a user's subscription when updating their CC info [Refs #168]

### DIFF
--- a/app/controllers/members/users_controller.rb
+++ b/app/controllers/members/users_controller.rb
@@ -39,9 +39,13 @@ class Members::UsersController < Members::MembersController
         customer.save
       end
       subscription = customer.subscriptions.first
-      subscription.plan = params[:plan]
+      if subscription
+        subscription.plan = params[:plan]
+        subscription.save
+      else # subscription may have been canceled due to non-payment
+        customer.subscriptions.create({:plan => params[:plan]})
+      end
 
-      subscription.save
     else
       stripe_customer = Stripe::Customer.create(
         email: params[:email],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'rspec/autorun'
 require 'capybara/rails'
 require 'rack_session_access/capybara'
 require 'shoulda/matchers'
+require 'stripe_mock'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Renew a user's subscription when updating their CC info, if they don't currently have an active subscription [Refs #168]

Add spec, and refactor existing specs around submitting dues to test using Stripe Mock
