### PR TITLE
Add an admin-only json listing of members & their profiles

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -12,6 +12,11 @@ class AdminController < ApplicationController
     @all_members = User.all_members
       .includes(:profile)
       .order_by_state
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @all_members.as_json(include: :profile) }
+    end
   end
 
   def approve

--- a/app/views/admin/members.html.haml
+++ b/app/views/admin/members.html.haml
@@ -8,4 +8,6 @@
     %li Key codes / physical keys
     %li The wiki
 
+  %p Want all the members as a big blob of json? #{ link_to "Here you go!", admin_members_path(format: :json) }
+
   = render partial: 'list', locals: { users: @all_members }

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -71,10 +71,28 @@ describe AdminController do
     end
 
     describe 'GET members' do
-      it 'allows admin to view admin members index' do
-        login_as(:voting_member, is_admin: true)
-        get :members
-        response.should render_template :members
+      context 'as HTML' do
+        it 'allows admin to view admin members index' do
+          login_as(:voting_member, is_admin: true)
+          get :members, format: 'html'
+          response.should render_template :members
+        end
+      end
+
+      context 'as JSON' do
+        let!(:member) { create(:member, name: 'Several Lemurs') }
+        let(:summary) { "We're like cats and bears mixed together and cute." }
+
+        before {
+          member.profile.update_column(:summary, summary)
+        }
+
+        it 'allows admin to view members as json' do
+          login_as(:voting_member, is_admin: true)
+          get :members, format: 'json'
+          response.body.should include "Several Lemurs"
+          response.body.should include summary
+        end
       end
     end
 
@@ -158,10 +176,20 @@ describe AdminController do
     end
 
     describe 'GET members' do
-      it 'should redirect to root if logged in as member' do
-        login_as(:member)
-        get :members
-        response.should redirect_to :root
+      context 'as HTML' do
+        it 'should redirect to root if logged in as member' do
+          login_as(:member)
+          get :members, format: 'html'
+          response.should redirect_to :root
+        end
+      end
+
+      context 'as JSON' do
+        it 'should redirect to root if logged in as member' do
+          login_as(:member)
+          get :members, format: 'json'
+          response.should redirect_to :root
+        end
       end
     end
 


### PR DESCRIPTION
This means membership coordinators can have membership data for doing fun things like buddy-making!

:tada: :tada: :tada: 
