### PR TITLE
Use https for gravatar urls

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,7 +122,7 @@ class User < ActiveRecord::Base
   def gravatar_url(size = 200)
     email = gravatar_email || self.email
     hash = email ? Digest::MD5.hexdigest(email.downcase) : nil
-    "http://www.gravatar.com/avatar/#{hash}?s=#{size}"
+    "https://www.gravatar.com/avatar/#{hash}?s=#{size}"
   end
 
   def create_profile


### PR DESCRIPTION
Fixes a mixed content warning on pages that display your gravatar if you're logged in (e.g. the application form page).

![screen shot 2015-06-11 at 7 22 40 pm](https://cloud.githubusercontent.com/assets/187987/8123031/ce03abdc-1077-11e5-9591-9df3c80ffb21.png)

:warning: cc @lilliealbert I didn't run the tests 'cause postgres. I promise I feel bad about it.
