### PR TITLE
Adding how to reach the membership coordinators

### DIFF
--- a/app/views/members/dues/show.html.haml
+++ b/app/views/members/dues/show.html.haml
@@ -20,6 +20,8 @@
 
 = render 'form', action: "Update"
 
+  %p If you'd like to cancel your Double Union membership or have other questions about dues and membership, please email membership@doubleunion.org to reach the membership coordinators.
+
 %h3 Apply for a Scholarship
 
 = render "scholarship_request"


### PR DESCRIPTION
When people want to leave DU, they sometimes aren't sure who to ask, since that info is deep in the Member Handbook. This adds a brief note to the Manage Dues page, which is where they're likely to look for how to cancel their dues.