### PR TITLE
Adding context and updates to application page

### DIFF
--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -1,7 +1,7 @@
 %h2 Membership application
 
 %p
-  Hello! We're glad you're interested in becoming a member of Double Union.
+  Hello! We're glad you're interested in becoming a member of Double Union. We love reading applications and look forward to meeting you if we haven't already.
 
 %p
   If you have any questions about the application or application process, please email our membership coordinators at #{ mail_to JOIN_EMAIL }.
@@ -13,9 +13,6 @@
   You can save this application at any time before you submit it. Once
   submitted, it will only be visible to Double Union members.  No part of this
   application will ever be public.
-
-%p
-  All fields are optional unless otherwise indicated.
 
 - if Configurable[:application_deadline_warning].present?
   .alert.alert-info
@@ -47,53 +44,53 @@
       = profile_fields.hidden_field :id
 
       %tr
-        %td= profile_fields.label :twitter, 'Twitter username'
+        %td= profile_fields.label :twitter, 'Twitter username (optional)'
         %td= profile_fields.text_field :twitter
 
       %tr
-        %td= profile_fields.label :facebook, 'Facebook url'
+        %td= profile_fields.label :facebook, 'Facebook URL (optional)'
         %td= profile_fields.text_field :facebook
 
       %tr
-        %td= profile_fields.label :website, 'Website url'
+        %td= profile_fields.label :website, 'Website URL (optional)'
         %td= profile_fields.text_field :website
 
       %tr
-        %td= profile_fields.label :linkedin, 'LinkedIn url'
+        %td= profile_fields.label :linkedin, 'LinkedIn URL (optional)'
         %td= profile_fields.text_field :linkedin
 
       %tr
-        %td= profile_fields.label :blog, 'Blog url'
+        %td= profile_fields.label :blog, 'Blog URL (optional)'
         %td= profile_fields.text_field :blog
 
       %tr
         %td
           = profile_fields.label :summary, 'Tell us a little about yourself!'
-          %small (2000 character maximum)
+          %small In this question, we're just curious to get an overall sense of your story. We don't evaluate applications based on how accomplished or successful a person is. Some sentences or a paragraph would be great; for all of these questions, we love getting to read some detail but don't want to burden you with writing a huge essay. Feel free to include extra URLs if you like. If you don't have a public online presence (such as Twitter or a website), which is fine, it can help us if you add a little extra here. (2000 character maximum.)
         %td= profile_fields.text_area :summary, rows: 10
 
       %tr
         %td
           = profile_fields.label :reasons, 'Why are you interested in joining Double Union?'
-          %small (2000 character maximum)
+          %small We ask this question since we'd like to know if you have interests and goals related to joining DU that are approximately compatible with the general broad goals of DU (and what it can offer to members). (2000 character maximum.)
         %td= profile_fields.text_area :reasons, rows: 10
 
       %tr
         %td
           = profile_fields.label :reasons, 'Tell us about your feminism!'
-          %small (2000 character maximum)
+          %small We ask this because we care about DU being an intersectional feminist space, and it's important to us that new members care about this too; we expect members to identify as feminist in some way. To help us understand your perspective, we'd like to hear about your thoughts around your own feminism. It's ok if you don't have a formal/academic way of talking about this! You may also find it helpful to look at our #{ link_to "base assumptions", BASE_ASSUMPTIONS_URL } since they help explain DU's shared values. (2000 character maximum.)
         %td= profile_fields.text_area :feminism, rows: 10
 
       %tr
         %td
           = profile_fields.label :projects, 'What would you like to work on in the space?'
-          %small (2000 character maximum)
+          %small We're curious! We sometimes look at these answers to help us figure out what kinds of workshops and events to hold during the membership application round (or as public events in general). This doesn't have to be long. (2000 character maximum)
         %td= profile_fields.text_area :projects, rows: 10
 
       %tr
         %td
           = profile_fields.label :skills, 'What skills are you most interested in learning, improving, and/or teaching?'
-          %small (2000 character maximum)
+          %small Same as above - we're curious! This doesn't have to be long. (2000 character maximum)
         %td= profile_fields.text_area :skills, rows: 10
 
       %tr.nested-table
@@ -112,7 +109,7 @@
 
               %tr
                 %td= app_fields.check_box :agreement_female
-                %td= app_fields.label :agreement_female, "I am significantly female-identified", class: 'checkbox-label'
+                %td= app_fields.label :agreement_female, "To keep the focus on a great space for women (trans, cis, queer, straight, and not-fitting-into-those-labels/other), all DU members identify as women in a way that's significant to them. This fits with my self-identification.", class: 'checkbox-label'
 
   - if @user.application.submitted?
     = f.submit 'Update application', name: 'save', class: "btn"

--- a/spec/features/apply_to_du_spec.rb
+++ b/spec/features/apply_to_du_spec.rb
@@ -13,7 +13,7 @@ describe "applying to double union" do
     visit new_application_path
 
     fill_in "Twitter username", with: "@beepboopbeep"
-    fill_in "Blog url", with: "http://blog.awesome.com"
+    fill_in "Blog URL", with: "http://blog.awesome.com"
     check "user_application_attributes_agreement_terms"
     check "user_application_attributes_agreement_policies"
     check "user_application_attributes_agreement_female"

--- a/spec/features/apply_to_du_spec.rb
+++ b/spec/features/apply_to_du_spec.rb
@@ -45,7 +45,7 @@ describe "applying to double union" do
     expect(page).to have_content "We're glad you're interested"
 
     fill_in "Twitter username", with: "@beepboopbeep"
-    fill_in "Blog url", with: "http://blog.awesome.com"
+    fill_in "Blog URL", with: "http://blog.awesome.com"
     check "user_application_attributes_agreement_terms"
     check "user_application_attributes_agreement_policies"
     check "user_application_attributes_agreement_female"


### PR DESCRIPTION
Here's a proposed revision to make the membership application easier to fill out in a way that helps application reviewers, with friendly guidance for applicants on what kinds of answers DU is looking for.

1. I added a bit of extra encouragement to the beginning just for fun.
2. I removed the note that all fields are optional, and I instead put "(optional)" notes on the definitely-optional fields (Twitter, Facebook, etc.) - since we really want people to give answers to all the open-ended questions.
3. I added context to each open-ended question. This text needs review to make sure it matches our intentions.
4. I updated the phrasing about gender identification to [match the phrasing on our site](http://www.doubleunion.org/membership).

Small visual issues:
* I wasn't sure how to add the "(optional)" notes in the right way that looks nice, so they look a little clunky.
* The checkboxes at the end may need some style adjustment since the last item is now longer than one line.

Thanks @lilliealbert again for helping me get Arooo set up on my computer!