### PR TITLE
Add voting member agreement form

### DIFF
--- a/app/controllers/members/voting_members_controller.rb
+++ b/app/controllers/members/voting_members_controller.rb
@@ -1,0 +1,30 @@
+class Members::VotingMembersController < Members::MembersController
+
+  ALL_AGREEMENTS = %w[confidentiality attended_training policy_agreement time_commitment voting_principles hard_conversations]
+
+  def edit
+  end
+
+  def update
+    if agreements_missing?
+      flash[:error] = "You must agree to the statements below to become a voting member."
+      return render :edit
+    elsif !current_user.voting_member?
+      current_user.update!(voting_policy_agreement: true)
+      flash[:message] = "Thank you for volunteering to serve as a voting member! A membership coordinator will be in touch soon."
+    end
+
+    redirect_to members_root_path
+  end
+
+  private
+
+  def agreements_missing?
+    return true if params[:agreements].nil?
+
+    agreements = params[:agreements]
+    !(agreements.keys.sort == ALL_AGREEMENTS.sort && agreements.values.all? { |x| x == "1" })
+  end
+end
+
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   EMAIL_PATTERN = /\A.+@.+\Z/
 
   attr_accessible :username, :name, :email, :profile_attributes,
-    :application_attributes, :email_for_google, :dues_pledge, :is_scholarship
+    :application_attributes, :email_for_google, :dues_pledge, :is_scholarship, :voting_policy_agreement
 
   validates :state, presence: true
 

--- a/app/views/admin/memberships/_members.html.haml
+++ b/app/views/admin/memberships/_members.html.haml
@@ -35,10 +35,11 @@
               %span.collapse{class: "save-failure-#{user.id}"} Note not saved :(
 
         %td.buttons
-          = form_for user, url: admin_change_membership_state_path(user) do |f|
-            = f.hidden_field(:id)
-            = f.hidden_field(:updated_state, value: :former_member)
-            = f.submit "Revoke DU Membership", class: "btn reject-btn", data: { confirm: "Are you sure you'd like to cancel #{user.name}'s DU membership?" }
+          - if user.voting_policy_agreement.present? && !user.voting_member?
+            = form_for user, url: admin_change_membership_state_path(user) do |f|
+              = f.hidden_field(:id)
+              = f.hidden_field(:updated_state, value: :voting_member)
+              = f.submit "Make Voting member", class: "btn accept-btn", data: { confirm: "Are you sure?" }
           - if user.voting_member?
             = form_for user, url: admin_change_membership_state_path(user) do |f|
               = f.hidden_field(:id)
@@ -49,12 +50,12 @@
               = f.hidden_field(:id)
               = f.hidden_field(:updated_state, value: :member)
               = f.submit "Revoke Key membership", class: "btn reject-btn", data: { confirm: "Are you sure?" }
-            = form_for user, url: admin_change_membership_state_path(user) do |f|
-              = f.hidden_field(:id)
-              = f.hidden_field(:updated_state, value: :voting_member)
-              = f.submit "Make Voting member", class: "btn accept-btn", data: { confirm: "Are you sure?" }
           - else
             = form_for user, url: admin_change_membership_state_path(user) do |f|
               = f.hidden_field(:id)
               = f.hidden_field(:updated_state, value: :key_member)
               = f.submit "Make Key member", class: "btn accept-btn", data: { confirm: "Are you sure?" }
+          = form_for user, url: admin_change_membership_state_path(user) do |f|
+            = f.hidden_field(:id)
+            = f.hidden_field(:updated_state, value: :former_member)
+            = f.submit "Revoke DU Membership", class: "btn reject-btn", data: { confirm: "Are you sure you'd like to cancel #{user.name}'s DU membership?" }

--- a/app/views/members/users/index.html.haml
+++ b/app/views/members/users/index.html.haml
@@ -1,6 +1,10 @@
-- if current_user.member?
+- if current_user.member? || current_user.key_member?
   .mt-20
-    = link_to "Become a key member!", edit_members_user_key_members_path(current_user), class: "btn btn-default"
+    - if current_user.member?
+      = link_to "Become a key member", edit_members_user_key_members_path(current_user), class: "btn btn-default"
+
+    - unless current_user.voting_member?
+      = link_to "Become a voting member", edit_members_user_voting_members_path(current_user), class: "btn btn-default"
 
 = render 'bookmarks'
 

--- a/app/views/members/voting_members/edit.html.haml
+++ b/app/views/members/voting_members/edit.html.haml
@@ -1,0 +1,38 @@
+%h1 Voting Member Agreement
+
+%p
+  Filling out this form makes you eligible to become a voting member, but a membership coordinator will still need to confirm
+  that you attended a voting member training and then give you voting member privileges in the app.
+
+%p Please make sure you've read through the following documents before filling out this form:
+
+%ul
+  %li= link_to "DU voting member policies", Configurable[:voting_member_policy_doc], target: "_blank"
+  %li= link_to "DU confidentiality policy", POLICIES_URL, target: "_blank"
+
+= form_tag members_user_voting_members_path(current_user.id), method: "patch" do
+  %p
+    = check_box_tag "agreements[confidentiality]", 1, false, required: true
+    = label_tag "agreements[confidentiality]", "I have read and agree to uphold the #{ link_to "confidentiality policy", POLICIES_URL, target: "_blank"}.".html_safe
+
+  %p
+    = check_box_tag "agreements[policy_agreement]", 1, false, required: true
+    = label_tag "agreements[policy_agreement]", "I have read and agree to uphold the #{ link_to "voting member policy document", Configurable[:voting_member_policy_doc], target: "_blank" }.".html_safe
+
+  %p
+    = check_box_tag "agreements[voting_principles]", 1, false, required: true
+    = label_tag "agreements[voting_principles]", "I agree to vote on applications according to the criteria laid out in the #{ link_to "voting member policy", Configurable[:voting_member_policy_doc] }.".html_safe
+
+  %p
+    = check_box_tag "agreements[attended_training]", 1, false, required: true
+    = label_tag "agreements[attended_training]", "I have attended a voting member training."
+
+  %p
+    = check_box_tag "agreements[time_commitment]", 1, false, required: true
+    = label_tag "agreements[time_commitment]", "I am able to dedicate 3-4 hours per week to voting during the membership drive."
+
+  %p
+    = check_box_tag "agreements[hard_conversations]", 1, false, required: true
+    = label_tag "agreements[hard_conversations]", "I am open to having uncomfortable discussions during the course of voting on applications."
+
+  = submit_tag "Submit", class: "btn"

--- a/config/configurable.yml
+++ b/config/configurable.yml
@@ -5,6 +5,9 @@ accepting_applications:
 application_deadline_warning:
   type: text
 
+voting_member_policy_doc:
+  type: text
+
 # This file controls what config variables you want to be able to allow your users
 # to set, as well as those you'll be able to access from within the application.
 # 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Doubleunion::Application.routes.draw do
       post 'scholarship_request' => "dues#scholarship_request"
 
       resource :key_members, only: [:edit, :update]
+      resource :voting_members, only: [:edit, :update]
     end
     resources :votes, only: [:create, :destroy]
 

--- a/db/migrate/20160109231413_add_voting_policy_agreement_to_users.rb
+++ b/db/migrate/20160109231413_add_voting_policy_agreement_to_users.rb
@@ -1,0 +1,5 @@
+class AddVotingPolicyAgreementToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :voting_policy_agreement, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141014030515) do
+ActiveRecord::Schema.define(version: 20160109231413) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 20141014030515) do
     t.datetime "last_stripe_charge_succeeded"
     t.string   "username"
     t.boolean  "is_scholarship",               default: false
+    t.boolean  "voting_policy_agreement",                  default: false
   end
 
   create_table "votes", force: true do |t|

--- a/spec/controllers/members/voting_members_controller_spec.rb
+++ b/spec/controllers/members/voting_members_controller_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+
+describe Members::VotingMembersController do
+  include AuthHelper
+
+  let(:member) { create :member }
+
+  describe "get edit" do
+
+    let(:subject) { get :edit, user_id: member }
+
+    it_should_behave_like "deny non-members", [:visitor, :applicant]
+    it_should_behave_like "allow members", [:member, :key_member]
+
+    context "logged in as a member" do
+      before { login_as member }
+
+      it "allows members to load the status edit form" do
+        subject
+        expect(response).to be_success
+        expect(response).to render_template :edit
+      end
+    end
+  end
+
+  describe "post update" do
+    let(:subject) { patch :update, user_id: member }
+
+    it_should_behave_like "deny non-members", [:visitor, :applicant]
+    it_should_behave_like "allow members", [:member, :key_member]
+
+    context "logged in as a member" do
+      before { login_as member }
+
+      context "with the agreement boxes checked" do
+        let(:params) { {
+          "user_id" => member.id,
+          "agreements" => {
+            "confidentiality" => "1", "attended_training" => "1", "policy_agreement" => "1",
+            "time_commitment" => "1", "voting_principles" => "1", "hard_conversations" => "1"
+          }
+        } }
+
+        let(:subject) { patch :update, params }
+
+        it "marks the member as having agreed to the voting member policies" do
+          expect { subject }.to change { member.reload.voting_policy_agreement }.from(false).to(true)
+        end
+
+        it "renders the members index with a flash" do
+          subject
+          expect(response).to redirect_to members_root_path
+          expect(flash[:message]).to include "Thank you for volunteering to serve as a voting member! A membership coordinator will be in touch soon."
+        end
+      end
+
+      context "with the agreement boxes unchecked" do
+        let(:params) { {
+          "user_id" => member.id,
+          "agreements" => { "confidentiality" => "1" }
+        } }
+
+        let(:subject) { patch :update, params }
+
+        it "does not set the voting policy agreement" do
+          expect { subject }.not_to change { member.voting_policy_agreement }.from(false)
+        end
+
+        it "rerenders the form with a flash" do
+          subject
+          expect(response).to render_template :edit
+          expect(flash[:error]).to include "You must agree to the statements below to become a voting member."
+        end
+      end
+    end
+  end
+end

--- a/spec/features/update_member_status_spec.rb
+++ b/spec/features/update_member_status_spec.rb
@@ -20,6 +20,26 @@ describe "becoming a key member" do
   end
 end
 
+describe "submitting the voting member agreement" do
+  let(:member) { create(:member) }
+
+  before { page.set_rack_session(user_id: member.id) }
+
+  it "allows a member to submit the voting member agreement" do
+    visit members_root_path
+    click_link "Become a voting member"
+    expect(page).to have_content "Voting Member Agreement"
+    check "I have read and agree to uphold the confidentiality policy."
+    check "I have read and agree to uphold the voting member policy document."
+    check "I agree to vote on applications according to the criteria laid out in the voting member policy."
+    check "I have attended a voting member training"
+    check "I am able to dedicate 3-4 hours per week to voting during the membership drive"
+    check "I am open to having uncomfortable discussions during the course of voting on applications."
+    click_on "Submit"
+    expect(page).to have_content "Thank you for volunteering to serve as a voting member! A membership coordinator will be in touch soon."
+  end
+end
+
 describe "marking members as on scholarship" do
   before { page.set_rack_session(user_id: admin.id) }
 
@@ -77,6 +97,29 @@ describe "updating membership status" do
         end
       end
 
+      context "who has agreed to the voting member agreement" do
+        before { member.update!(voting_policy_agreement: true) }
+
+        it "allows a member to become a voting member" do
+          visit admin_memberships_path
+          click_button "Make Voting member"
+
+          expect(page).to have_content "#{member.name} is now a voting member."
+          within(".user-#{member.id}") do
+            expect(page).to have_content "voting member"
+          end
+        end
+      end
+
+      context "who has not agreed to the voting member agreement" do
+        it "does not show the make voting member button" do
+          visit admin_memberships_path
+          click_button "Make Key member"
+
+          expect(page).not_to have_content "Make voting member"
+        end
+      end
+
       it "allows membership to be cancelled" do
         visit admin_memberships_path
         within(".user-#{member.id}") do
@@ -116,7 +159,7 @@ describe "updating membership status" do
     context "with a voting member" do
       let!(:member) { create :voting_member }
 
-      it "allows key membership to be cancelled" do
+      it "allows voting membership to be cancelled" do
         visit admin_memberships_path
         within(".user-#{member.id}") do
           click_button "Revoke Voting membership"


### PR DESCRIPTION
Here's what I've got so far for the voting member agreement form. I still need the links for the official voting policy, but I've set it up such that the URL can be added on the admin configurations page, underneath where we enable/disable applications.

How it works:
- Non-voting members will see a button to become a voting member on the app home page, eerily similar to the "Become a key member" button.
- Submitting the form will mark the member as having agreed to the voting member policies in the app
- The "making voting member" button will then show up for this member in the admin page for managing members

Please add any suggested text updates in the comments! :rocket: 

![screen shot 2016-01-23 at 5 58 06 pm](https://cloud.githubusercontent.com/assets/978428/12534002/fa91c596-c1fa-11e5-9557-e5d9285a3889.png)
