### PR TITLE
Updating key member form

### DIFF
--- a/app/views/members/key_members/edit.html.haml
+++ b/app/views/members/key_members/edit.html.haml
@@ -1,7 +1,7 @@
 %h1 Become a key member!
 
-%p Keymembers can access Double Union 24/7, host events, and bring guests of any gender.
-%p When you submit this form, we'll email the membership coordinators and the chatelaines (who hold the keys) to arrange a time for you to get your keys!
+%p Keymembers can access Double Union 24/7, host events, and bring guests of any gender. Learn more in the #{ link_to "Members Handbook about key membership", "https://docs.google.com/document/d/1yYXAj8rzQMiYt2xFdzm2xEOe0LCHohWNrMWzad-4mtQ/edit#heading=h.lsg2zdao236h" }.
+%p Before filling out this form, note that a requirement for keymembership is to have attended at least two events at DU (including at least one members meeting or orientation); if you haven't done that yet, do that first. :) When you submit this form, it'll email the membership coordinators to ask them to arrange a time with you to get you set up with access to the space (including a key code and smartlock access). You can also email them at membership@doubleunion.org to follow up.
 
 = form_tag members_user_key_members_path(current_user.id), method: "patch" do
   %p


### PR DESCRIPTION
Fixing the issues at https://github.com/doubleunion/arooo/issues/214 - linking to the member handbook, noting the requirement to attend events, updating from keys to keycode + smartlock access.