### PR TITLE
Minor: Fix html meta tag structure

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,12 +2,12 @@
 %html
   %head
     %meta{ content: 'width=device-width, initial-scale=1.0', name: 'viewport' }
-      %title= html_title
-      %meta{ content: html_description, name: 'description' }
-        = stylesheet_link_tag 'application', media: 'all'
-        = stylesheet_link_tag 'admin', media: 'all' if members_page?
-        = csrf_meta_tags
-        = yield(:head)
+    %title= html_title
+    %meta{ content: html_description, name: 'description' }
+    = stylesheet_link_tag 'application', media: 'all'
+    = stylesheet_link_tag 'admin', media: 'all' if members_page?
+    = csrf_meta_tags
+    = yield(:head)
   %body{ class: body_classes.join(' ') }
     .wrapper
       = render 'layouts/navigation'


### PR DESCRIPTION
This fixes some weirdness where other head tags were nested inside two meta tags, and makes the HTML valid-er. :sparkles: 