### PR TITLE
Update acceptance email

### DIFF
--- a/app/views/applications_mailer/approved.html.haml
+++ b/app/views/applications_mailer/approved.html.haml
@@ -7,8 +7,6 @@
 
       %p As soon as possible, log into #{ link_to "the site", EXTERNAL_SITE_URL } ("Log in" is at top right) and confirm your membership #{ link_to "on this page", members_user_setup_url(@user.id) }. This is where you'll give us your Google Drive-friendly email address, set up dues (or apply for a scholarship), and check your subscription to the members' mailing list. (A membership coordinator will subscribe you to the mailing list soon. Feel free to start a thread introducing yourself and jump into conversations right away.)
 
-      %p After you're done with that, check out the current applications to DU & let us know if you know any of the applicants! Only voting members vote, but everyone can (and should) comment on applications: #{ link_to "doubleunion.org", members_applications_url }. (You'll be able to sponsor applications after two weeks as a member.)
-
       %p If you want to be listed publicly as a member (at the bottom of #{ link_to "this page", MEMBERSHIP_URL }), #{ link_to "log in", login_url } to the app and go to "Edit profile" in the right dropdown menu. There's a checkbox there marked "Show name/website/gravatar on public site?"
 
       %p Things the membership coordinators will do for you:


### PR DESCRIPTION
We've switched to accepting applicants in a big batch, so brand-new members won't see any applications.