### PR TITLE
Revert "Add Preferred Pronoun to Profile"

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -66,7 +66,7 @@ class ApplicationsController < ApplicationController
   end
 
   def profile_attributes
-    [:id, :twitter, :pronoun, :facebook, :website, :linkedin, :blog,
+    [:id, :twitter, :facebook, :website, :linkedin, :blog,
      :summary, :reasons, :feminism, :projects, :skills ]
   end
 

--- a/app/views/applications/_show.html.haml
+++ b/app/views/applications/_show.html.haml
@@ -11,11 +11,7 @@
       Email
       %small (required)
     %td= @user.email
-  %tr
-    %td.left
-      Pronouns
-      %small (optional)
-      %p.small *This does not affect your application, Double Union wants to respect what pronouns you use
+
   %tr
     %td.left Twitter url
     %td= external_auto_link(@user.profile.twitter_url)

--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -49,13 +49,6 @@
 
       %tr
         %td
-          = profile_fields.label :pronoun, "Pronoun"
-          %small (optional)
-          %p.small *This does not affect your application, Double Union wants to respect what pronouns you use
-        %td= profile_fields.text_field :pronoun
-
-      %tr
-        %td
           = profile_fields.label :twitter, 'Twitter username'
           %small (optional)
         %td= profile_fields.text_field :twitter

--- a/db/migrate/20160615035631_add_pronoun_to_profiles.rb
+++ b/db/migrate/20160615035631_add_pronoun_to_profiles.rb
@@ -1,5 +1,0 @@
-class AddPronounToProfiles < ActiveRecord::Migration
-  def change
-    add_column :profiles, :pronoun, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160615035631) do
+ActiveRecord::Schema.define(version: 20160206222501) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,7 +75,6 @@ ActiveRecord::Schema.define(version: 20160615035631) do
     t.string   "projects",          limit: 2000
     t.string   "skills",            limit: 2000
     t.string   "feminism",          limit: 2000
-    t.string   "pronoun"
   end
 
   add_index "profiles", ["user_id"], name: "index_profiles_on_user_id", using: :btree

--- a/spec/features/apply_to_du_spec.rb
+++ b/spec/features/apply_to_du_spec.rb
@@ -14,7 +14,6 @@ describe "applying to double union" do
 
     fill_in "Twitter username", with: "@beepboopbeep"
     fill_in "Blog URL", with: "http://blog.awesome.com"
-    fill_in "Pronoun", with: "They/Them"
     check "user_application_attributes_agreement_terms"
     check "user_application_attributes_agreement_policies"
     check "user_application_attributes_agreement_female"


### PR DESCRIPTION
Reverts doubleunion/arooo#241

There was a problem trying to save the Pronoun field when I tried on staging, and we forgot to put the field in the profiles so members can see them later. I would like to revert this change for now, as it needs some more tweaks!