### PR TITLE
Link to checklist instead of duplicating list

### DIFF
--- a/app/views/admin/memberships/index.html.haml
+++ b/app/views/admin/memberships/index.html.haml
@@ -5,13 +5,7 @@
   .col-md-9.col-md-offset-1
     - if @all_members.any?
       %h3 Admin Membership Console
-      %p Changing state on these buttons doesn't do anything except update the app. You'll still need to inform the person of the status change and add/remove permissions to things as necessary, such as:
-      %ul
-        %li Mailing lists
-        %li Google Drive folders
-        %li Member's Google Calendar
-        %li Key codes / physical keys
-        %li Slack chat
+      %p Changing state on these buttons doesn't do anything except update the app. You'll still need to inform the person of the status change and add/remove permissions to things as necessary. See our checklists: { link_to "How to add/remove membership privileges", "https://docs.google.com/document/d/1udA9ygbX8IVop3yD8ZcsmH5_C2C2liznCLDSJvYaSg4/edit" }.
 
       %hr
 


### PR DESCRIPTION
Closes https://github.com/doubleunion/arooo/issues/138 - our member privileges onboarding/offboarding checklist needs to change regularly (as we add or remove services we use as DU), so we should link to that Google Doc instead of trying to make this bit of the app super helpful.