### PR TITLE
Members can Self-Cancel Stripe Dues ✨

### DIFF
--- a/app/assets/javascripts/dues.js
+++ b/app/assets/javascripts/dues.js
@@ -18,4 +18,14 @@ $(document).ready(function(){
     });
     e.preventDefault();
   });
+
+
+
+  $('.cancel-membership').click(
+  function (e) {
+    e.preventDefault();
+    $('#cancel-btn').removeClass('hidden');
+    $('#cancel-btn').addClass('cancel');
+  }
+);
 });

--- a/app/assets/stylesheets/admin.css.scss
+++ b/app/assets/stylesheets/admin.css.scss
@@ -70,3 +70,10 @@ body.applications.show {
 .admin-warning {
   color: red;
 }
+
+.cancel {
+  background-color: red;
+  &:hover {
+    background-color: #a41f2b ;
+  }
+}

--- a/app/assets/stylesheets/utilities.css.scss
+++ b/app/assets/stylesheets/utilities.css.scss
@@ -29,3 +29,7 @@
 .pt-10 {
   padding-top: 10px;
 }
+
+.hidden {
+  display: none;
+}

--- a/app/controllers/members/dues_controller.rb
+++ b/app/controllers/members/dues_controller.rb
@@ -9,6 +9,21 @@ class Members::DuesController < Members::MembersController
     end
   end
 
+  def cancel
+    message = "You don't have an active membership dues subscription"
+    if current_user.stripe_customer_id
+      customer = Stripe::Customer.retrieve(current_user.stripe_customer_id)
+      @subscription = customer.subscriptions.first
+
+      if @subscription
+        @subscription.delete
+        message = "Your dues have now been canceled"
+      end
+    end
+    flash[:notice] = message
+    redirect_to members_user_dues_path(current_user)
+  end
+
   def update
     @user = current_user
 

--- a/app/views/layouts/_messages.html.haml
+++ b/app/views/layouts/_messages.html.haml
@@ -1,6 +1,6 @@
 - flash.each do |name, msg|
   - if msg.is_a?(String)
     .container
-      %div{class: "alert alert-#{name == :notice ? 'success' : 'warning'}"}
+      %div{class: "alert alert-#{name == "notice" ? 'info' : 'warning'}"}
         %a.close{'data-dismiss' => 'alert'} ×
         = content_tag :div, msg, id: "flash_#{name}"

--- a/app/views/members/dues/show.html.haml
+++ b/app/views/members/dues/show.html.haml
@@ -22,8 +22,13 @@
 
 = render 'form', action: "Update"
 
-%p If you'd like to cancel your Double Union membership or have other questions about dues and membership, please email #{ mail_to MEMBERSHIP_EMAIL } to reach the membership coordinators.
 
 %h3 Apply for a Scholarship
 
 = render "scholarship_request"
+
+.cancel-membership
+  %h3 Cancel your Membership
+  %p If you'd like to cancel your Double Union membership, click #{link_to "here", class: "cancel-membership"}. If you have other questions about dues and membership, please email #{ mail_to MEMBERSHIP_EMAIL } to reach out to the membership coordinators.
+
+  = button_to("Cancel", members_user_cancel_path, method: :delete, id: "cancel-btn", class: "btn btn-primary hidden", data: { confirm: "Are you sure?" } )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Doubleunion::Application.routes.draw do
       patch 'setup' => "users#finalize"
 
       resource :dues, only: [:show, :update]
+      delete 'cancel' => "dues#cancel"
       post 'scholarship_request' => "dues#scholarship_request"
 
       resource :key_members, only: [:edit, :update]


### PR DESCRIPTION
A work in progress branch. 
@mathildemouw and @lilliealbert : @heyellieday and I are pairing on feature #242 and we just wanted to give you a chance to checkout what we have so far:
- initial specs for cancelling a subscription
- controller action that cancels the subscription

We plan on making the spec more DRY, handling potential Stripe errors, in addition to adding a button in the view and an email that's sent out on successful cancellation.
