### PR TITLE
Enable Applicants and Members to Display and Edit Pronouns

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -66,7 +66,7 @@ class ApplicationsController < ApplicationController
   end
 
   def profile_attributes
-    [:id, :twitter, :facebook, :website, :linkedin, :blog,
+    [:id, :twitter, :pronouns, :facebook, :website, :linkedin, :blog,
      :summary, :reasons, :feminism, :projects, :skills ]
   end
 

--- a/app/controllers/members/users_controller.rb
+++ b/app/controllers/members/users_controller.rb
@@ -45,7 +45,7 @@ class Members::UsersController < Members::MembersController
 
   def profile_attributes
     [:id, :twitter, :facebook, :website, :linkedin, :blog,
-     :summary, :reasons, :projects, :skills,
+     :summary, :reasons, :projects, :pronouns, :skills,
      :show_name_on_site, :gravatar_email]
   end
 

--- a/app/views/applications/_show.html.haml
+++ b/app/views/applications/_show.html.haml
@@ -11,7 +11,12 @@
       Email
       %small (required)
     %td= @user.email
-
+  %tr
+    %td.left
+      Pronouns
+      %small (optional)
+      %p.small *This does not affect your application. Double Union members want to use your correct pronouns.
+    %td= @user.profile.pronouns
   %tr
     %td.left Twitter url
     %td= external_auto_link(@user.profile.twitter_url)

--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -49,6 +49,14 @@
 
       %tr
         %td
+          = profile_fields.label :pronouns, 'Pronouns'
+
+          %p.small What #{ link_to "pronouns", BRYN_MAWR_PRONOUNS_URL, target: "_blank" } should people use for you at Double Union, such as at events? (This doesn't affect your application, we just want to know how to refer to you respectfully.)
+
+        %td= profile_fields.text_field :pronouns
+
+      %tr
+        %td
           = profile_fields.label :twitter, 'Twitter username'
           %small (optional)
         %td= profile_fields.text_field :twitter
@@ -106,7 +114,7 @@
             that new members care about this too; we expect members to identify as feminist in some way. To help us
             understand your perspective, we'd like to hear about your thoughts around your own feminism. It's ok if you
             don't have a formal/academic way of talking about this! You may also find it helpful to look at our
-            #{ link_to "base assumptions", BASE_ASSUMPTIONS_URL } since they help explain DU's shared values.
+            #{ link_to "base assumptions", BASE_ASSUMPTIONS_URL, target: "_blank" } since they help explain DU's shared values.
           %p.small Required — 2000 character maximum.
         %td= profile_fields.text_area :feminism, rows: 10
 

--- a/app/views/members/users/edit.html.haml
+++ b/app/views/members/users/edit.html.haml
@@ -25,6 +25,10 @@
       = f.text_field :name
 
     %fieldset
+      %legend= fields.label :pronouns, 'Pronouns'
+      = fields.text_field :pronouns
+
+    %fieldset
       %legend= f.label :email, 'Email'
       = f.text_field :email
 

--- a/app/views/members/users/show.html.haml
+++ b/app/views/members/users/show.html.haml
@@ -4,6 +4,8 @@
   = user_gravatar(@user, 150)
 
 %h2= @user.name if @user.name.present?
+- if profile.pronouns.present?
+  %h4= profile.pronouns
 
 - if @user.email.present?
   %h4= @user.email

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,17 +1,17 @@
-TWITTER_USERNAME     = 'doubleunionsf'
-TWITTER_URL          = "https://twitter.com/#{TWITTER_USERNAME}"
+TWITTER_USERNAME       = 'doubleunionsf'
+TWITTER_URL            = "https://twitter.com/#{TWITTER_USERNAME}"
 
-PRESS_EMAIL          = 'press@doubleunion.org'
-PAYPAL_EMAIL         = 'paypal@doubleunion.org'
-CONTACT_EMAIL        = 'doubleunionsf@gmail.com'
-JOIN_EMAIL           = I18n.t('du.join_email')
-MEMBERSHIP_EMAIL     = I18n.t('du.membership_email')
-BOARD_EMAIL          = I18n.t('du.board_email')
-KEYS_EMAIL           = "keys@doubleunion.org"
-SCHOLARSHIP_EMAIL    = "scholarship@doubleunion.org"
+PRESS_EMAIL            = 'press@doubleunion.org'
+PAYPAL_EMAIL           = 'paypal@doubleunion.org'
+CONTACT_EMAIL          = 'doubleunionsf@gmail.com'
+JOIN_EMAIL             = I18n.t('du.join_email')
+MEMBERSHIP_EMAIL       = I18n.t('du.membership_email')
+BOARD_EMAIL            = I18n.t('du.board_email')
+KEYS_EMAIL             = "keys@doubleunion.org"
+SCHOLARSHIP_EMAIL      = "scholarship@doubleunion.org"
 
-TUMBLR_BASE          = 'doubleunion.tumblr.com'
-TUMBLR_URL           = "http://#{TUMBLR_BASE}"
+TUMBLR_BASE            = 'doubleunion.tumblr.com'
+TUMBLR_URL             = "http://#{TUMBLR_BASE}"
 
 MAILING_LIST_GENERAL = "http://lists.doubleunion.org/listinfo.cgi/doubleunion-doubleunion.org"
 GOOGLE_ANALYTICS_ID  = 'UA-47411942-1'
@@ -25,3 +25,4 @@ LOCK_UP_DOC          = "https://docs.google.com/document/d/1rFoyl5FJjDdr0LqiVacQ
 VOTING_CRITERIA_DOC  = "https://docs.google.com/document/d/12R7utXAiyCK55XEP8cPscUqu2CXAj-hL5jXE-MaJdgE/edit#heading=h.w83btzy2bttc"
 COMMENTING_DOC       = "https://docs.google.com/document/d/12R7utXAiyCK55XEP8cPscUqu2CXAj-hL5jXE-MaJdgE/edit#heading=h.ti79qe36hzgp"
 VOTING_PROCESS_DOC   = "https://docs.google.com/document/d/12R7utXAiyCK55XEP8cPscUqu2CXAj-hL5jXE-MaJdgE/edit#heading=h.y6eimvxrwzvf"
+BRYN_MAWR_PRONOUNS_URL = "http://www.brynmawr.edu/pensby/documents/AskingforNameandPronouns.pdf"

--- a/db/migrate/20161205063620_add_pronouns_to_profiles.rb
+++ b/db/migrate/20161205063620_add_pronouns_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddPronounsToProfiles < ActiveRecord::Migration
+  def change
+    add_column :profiles, :pronouns, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160206222501) do
+ActiveRecord::Schema.define(version: 20161205063620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 20160206222501) do
     t.string   "projects",          limit: 2000
     t.string   "skills",            limit: 2000
     t.string   "feminism",          limit: 2000
+    t.string   "pronouns"
   end
 
   add_index "profiles", ["user_id"], name: "index_profiles_on_user_id", using: :btree

--- a/spec/features/apply_to_du_spec.rb
+++ b/spec/features/apply_to_du_spec.rb
@@ -14,6 +14,7 @@ describe "applying to double union" do
 
     fill_in "Twitter username", with: "@beepboopbeep"
     fill_in "Blog URL", with: "http://blog.awesome.com"
+    fill_in "Pronouns", with: "They/Them"
     check "user_application_attributes_agreement_terms"
     check "user_application_attributes_agreement_policies"
     check "user_application_attributes_agreement_female"
@@ -23,6 +24,7 @@ describe "applying to double union" do
     }.to change { cool_lady.application.reload.state }.from("started").to("submitted")
 
     expect(page).to have_content "Application submitted!"
+    expect(find_field('Pronouns').value).to eq "They/Them"
     expect(find_field('Twitter username').value).to eq "@beepboopbeep"
   end
 
@@ -44,6 +46,7 @@ describe "applying to double union" do
     visit new_application_path
     expect(page).to have_content "We're glad you're interested"
 
+    fill_in "Pronouns", with: "They/Them"
     fill_in "Twitter username", with: "@beepboopbeep"
     fill_in "Blog URL", with: "http://blog.awesome.com"
     check "user_application_attributes_agreement_terms"
@@ -52,10 +55,12 @@ describe "applying to double union" do
 
     click_on "Submit application"
 
+    fill_in "Pronouns", with: "Ze/Zir"
     fill_in "Twitter username", with: "@new_and_better_handle"
 
     first(:button, "Update application").click
 
+    expect(find_field('Pronouns').value).to eq "Ze/Zir"
     expect(find_field('Twitter username').value).to eq "@new_and_better_handle"
   end
 


### PR DESCRIPTION
Applicants are able to:
- preview their pronouns on the application preview page
- edit their pronouns before submitting

Members are able to: 
- see their own pronouns on their profile page, directly underneath their names
- see fellow members' pronouns
- edit their own pronouns

The copy surrounding asking Prospective Applicants about their pronoun-usage was crowd-surfed amongst Double Union members. We utilized [Bryn Mawr's](http://www.brynmawr.edu/pensby/documents/AskingforNameandPronouns.pdf) explanation regarding pronoun-usage.
