### PR TITLE
Fix stripe cancel button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,12 +57,14 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'chromedriver-helper'
   gem 'database_cleaner', '1.0.1'
   gem 'email_spec'
+  gem 'factory_girl_rails'
   gem 'launchy'
   gem 'machinist'
-  gem 'factory_girl_rails'
+  gem 'rspec-collection_matchers'
+  gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'stripe-ruby-mock', '~> 2.2.1', :require => 'stripe_mock'
-  gem 'rspec-collection_matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    archive-zip (0.7.0)
+      io-like (~> 0.3.0)
     arel (6.0.4)
     autoprefixer-rails (6.2.3)
       execjs
@@ -81,6 +83,11 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.1.0)
+      archive-zip (~> 0.7.0)
+      nokogiri (~> 1.6)
     coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -115,6 +122,7 @@ GEM
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    ffi (1.9.18)
     figaro (1.1.1)
       thor (~> 0.14)
     globalid (0.4.1)
@@ -138,6 +146,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jbuilder (1.5.3)
       activesupport (>= 3.0.0)
       multi_json (>= 1.2.0)
@@ -285,12 +294,16 @@ GEM
     rspec-support (3.7.0)
     ruby_parser (3.7.2)
       sexp_processor (~> 4.1)
+    rubyzip (1.2.1)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.2.2)
       sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
+    selenium-webdriver (3.8.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
     sexp_processor (4.6.0)
     shoulda-matchers (3.0.1)
       activesupport (>= 4.0.0)
@@ -353,6 +366,7 @@ DEPENDENCIES
   bootstrap-sass
   bugsnag
   capybara
+  chromedriver-helper
   coffee-rails (~> 4.0.0)
   configurable_engine
   database_cleaner (= 1.0.1)
@@ -386,6 +400,7 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-rails (~> 3.1)
   sass-rails (~> 4.0.0)
+  selenium-webdriver
   shoulda-matchers
   state_machine!
   stripe

--- a/app/assets/javascripts/dues.js
+++ b/app/assets/javascripts/dues.js
@@ -18,12 +18,4 @@ $(document).ready(function(){
     });
     e.preventDefault();
   });
-
-  $('.cancel-membership').click(
-  function (e) {
-    e.preventDefault();
-    $('#cancel-btn').removeClass('hidden');
-    $('#cancel-btn').addClass('cancel');
-  }
-);
 });

--- a/app/controllers/members/dues_controller.rb
+++ b/app/controllers/members/dues_controller.rb
@@ -17,9 +17,10 @@ class Members::DuesController < Members::MembersController
 
       if @subscription
         @subscription.delete
-        message = "Your dues have now been canceled"
+        message = "Your dues have now been canceled, and the membership coordinator will remove you from mailing lists shortly."
       end
     end
+    CancelMembershipMailer.cancel(current_user).deliver_now
     flash[:notice] = message
     redirect_to members_user_dues_path(current_user)
   end

--- a/app/mailers/cancel_membership_mailer.rb
+++ b/app/mailers/cancel_membership_mailer.rb
@@ -1,0 +1,14 @@
+class CancelMembershipMailer < ActionMailer::Base
+  default from: "Double Union <#{MEMBERSHIP_EMAIL}>"
+
+  def cancel(user)
+    @user = user
+
+    mail(
+      to: [MEMBERSHIP_EMAIL],
+      cc: [user.email],
+      subject: "#{user.name} is canceling their membership.",
+      body: "Please remove #{user.name} from all mailing lists."
+    )
+  end
+end

--- a/app/views/members/dues/show.html.haml
+++ b/app/views/members/dues/show.html.haml
@@ -29,4 +29,4 @@
 
 .cancel-membership
   %h3 Cancel your Membership
-  %p If you'd like to cancel your Double Union membership, click #{link_to "here", members_user_cancel_path, method: :delete, id: "cancel-btn", data: { confirm: "Are you sure?" } }. If you have other questions about dues and membership, please email #{ mail_to MEMBERSHIP_EMAIL } to reach out to the membership coordinators.
+  %p If you'd like to cancel your Double Union membership, click #{link_to "here", members_user_cancel_path, method: :delete, id: "cancel-btn", data: { confirm: "Are you sure? Clicking yes will cancel your payments, and inform the membership coordinator to remove you from all mailing lists." } }. If you have other questions about dues and membership, please email #{ mail_to MEMBERSHIP_EMAIL } to reach out to the membership coordinators.

--- a/app/views/members/dues/show.html.haml
+++ b/app/views/members/dues/show.html.haml
@@ -29,6 +29,4 @@
 
 .cancel-membership
   %h3 Cancel your Membership
-  %p If you'd like to cancel your Double Union membership, click #{link_to "here", class: "cancel-membership"}. If you have other questions about dues and membership, please email #{ mail_to MEMBERSHIP_EMAIL } to reach out to the membership coordinators.
-
-  = button_to("Cancel", members_user_cancel_path, method: :delete, id: "cancel-btn", class: "btn btn-primary hidden", data: { confirm: "Are you sure?" } )
+  %p If you'd like to cancel your Double Union membership, click #{link_to "here", members_user_cancel_path, method: :delete, id: "cancel-btn", data: { confirm: "Are you sure?" } }. If you have other questions about dues and membership, please email #{ mail_to MEMBERSHIP_EMAIL } to reach out to the membership coordinators.

--- a/spec/controllers/members/dues_controller_spec.rb
+++ b/spec/controllers/members/dues_controller_spec.rb
@@ -77,6 +77,10 @@ describe Members::DuesController do
         expect{customer.subscriptions.retrieve(canceled_subscription_id)}.to raise_error(Stripe::InvalidRequestError)
         expect(subject).to redirect_to members_user_dues_path(user)
       end
+
+      it "emails the membership coordinator" do
+        expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
     end
   end
 

--- a/spec/features/cancel_membership_spec.rb
+++ b/spec/features/cancel_membership_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+require 'stripe_mock'
+
+describe "canceling dues", js: true do
+  include UserWithOmniauth
+  include AuthHelper
+
+  let(:member) { create_with_omniauth(OmniAuth.config.mock_auth[:github]) }
+  let(:stripe_customer_id) { "123abc" }
+  let(:plan) {
+    OpenStruct.new(
+      :id => "test_plan",
+      :amount => 5000,
+      :currency => "usd",
+      :interval => "month",
+      :name => "test plan"
+    )
+  }
+  let(:subscription) {
+    OpenStruct.new(
+      status: "active",
+      plan: plan
+    )
+  }
+  let(:customer) {
+    Stripe::Customer.create(
+      {
+        id: stripe_customer_id,
+        email: member.email,
+        source: StripeMock.generate_card_token({}),
+        subscriptions: [ subscription ]
+      }
+    )
+  }
+
+  before do
+    member.update_attribute(:state, "key_member")
+    member.update_attribute(:dues_pledge, 10)
+    member.update_attribute(:stripe_customer_id, stripe_customer_id)
+    member.update_attribute(:setup_complete, true)
+
+    StripeMock.start
+    Stripe.api_key = "coolapikey"
+  end
+
+  after do
+    StripeMock.stop
+  end
+
+  it "a member can cancel their membership" do
+    visit root_path
+    click_on "Sign in with GitHub"
+    expect(page).to have_content "Bookmarks for Members"
+
+    allow(Stripe::Customer).to receive(:retrieve).
+      with(member.stripe_customer_id).
+      and_return(customer)
+
+    click_on "Manage Dues"
+    expect(page).to have_content "Manage Your Double Union Dues"
+    message = accept_alert do
+      click_link "here"
+    end
+    expect(message).to eq "Are you sure? Clicking yes will cancel your payments, and inform the membership coordinator to remove you from all mailing lists."
+
+    expect(page).to have_content "Your dues have now been canceled"
+  end
+end

--- a/spec/mailers/cancel_membership_mailer_spec.rb
+++ b/spec/mailers/cancel_membership_mailer_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe CancelMembershipMailer do
+  let(:member) { create :member }
+
+  describe "when cancellation email" do
+    let(:mail) { CancelMembershipMailer.cancel(member) }
+
+    it "is sent to the correct addresses" do
+      expect(mail.to).to include MEMBERSHIP_EMAIL
+      expect(mail.cc).to include member.email
+    end
+
+    it "has the right subject" do
+      expect(mail.subject).to include member.name
+    end
+
+    it "has the correct information" do
+      expect(mail.body).to eq "Please remove #{member.name} from all mailing lists."
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,10 @@ require 'rack_session_access/capybara'
 require 'shoulda/matchers'
 require 'stripe_mock'
 
+Capybara.register_driver :selenium do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
@@ -53,7 +57,10 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  # We use DatabaseCleaner. Using the built in transactional fixtures doesn't
+  # work with feature specs, as creating a user and logging in are separate
+  # threads.
+  config.use_transactional_fixtures = false
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,9 @@ require 'shoulda/matchers'
 require 'stripe_mock'
 
 Capybara.register_driver :selenium do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('headless')
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
 # Requires supporting ruby files with custom matchers and macros, etc,


### PR DESCRIPTION
Fixes stripe cancel button so that the member's dues are cancelled, and the membership coordinator receives an email informing them to remove the member from all mailing lists.