### PR TITLE
Change gender criteria

### DIFF
--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -151,7 +151,7 @@
 
               %tr
                 %td.pt-10= app_fields.check_box :agreement_female
-                %td.pt-10.pl-10= app_fields.label :agreement_female, "To keep the focus on a great space for women (trans, cis, queer, straight, and not-fitting-into-those-labels/other), all DU members identify as women in a way that's significant to them. This fits with my self-identification.", class: 'checkbox-label'
+                %td.pt-10.pl-10= app_fields.label :agreement_female, "To keep the focus on a great space for women and non-binary people (trans, cis, queer, straight, and not-fitting-into-those-labels/other), all DU members identify as a woman or non-binary person in a way that is significant to them. This fits with my self-identification.", class: 'checkbox-label'
 
   - if @user.application.submitted?
     = f.submit 'Update application', name: 'save', class: "btn"


### PR DESCRIPTION
We are changing "identify as a woman in a way that's significant to them" to "identify as a woman or non-binary person in a way that is significant to them" as per the large group discussion and the official vote by the board yesterday! 

Closes https://github.com/doubleunion/arooo/issues/281