### PR TITLE
'bundle' error specific to High Sierra

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ If you're a Double Union member, you can chat with the maintainers in our [#du-a
 
 ## Development setup
 
+NOTE: The 'bundle install' command below will not work if you have Mac OSX High Sierra. The libv8 dependency is not supported. We are actively working on a fix!
+
 If you are new to Rails, follow the [RailsBridge Installfest instructions](http://installfest.railsbridge.org/installfest/) for getting your environment set up.
 - You must follow the Railsbridge Installfest instructions if you do not have `ruby`, `bundler`, or `rails` installed before continuing.
 


### PR DESCRIPTION
here is the error message that I am getting when I run 'bundle install'. Adding a note to the ReadMe after talking with Chandrika.
....
Fetching libv8 3.16.14.13
Installing libv8 3.16.14.13 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/lyrahall/.gem/ruby/2.3.5/gems/libv8-3.16.14.13/ext/libv8
/Users/lyrahall/.rubies/ruby-2.3.5/bin/ruby -r ./siteconf20180130-29200-9xnexj.rb extconf.rb
creating Makefile
Compiling v8 for x64
Using python 2.7.10
Using compiler: /usr/bin/c++ (clang version 9.0.0)
../src/bignum.cc:761:7: error: variable 'i' is incremented both in the loop header and in the
loop body [-Werror,-Wfor-loop-analysis]
    ++i;
      ^
../src/bignum.cc:756:72: note: incremented here
  for (int i = other.used_digits_ + exponent_diff; i < used_digits_; ++i) {
                                                                       ^
1 error generated.
make[1]: ***
[/Users/lyrahall/.gem/ruby/2.3.5/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/bignum.o]
Error 1
make: *** [x64.release] Error 2
/Users/lyrahall/.gem/ruby/2.3.5/gems/libv8-3.16.14.13/ext/libv8/location.rb:36:in `block in
verify_installation!': libv8 did not install properly, expected binary v8 archive
'/Users/lyrahall/.gem/ruby/2.3.5/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/tools/gyp/libv8_base.a'to
exist, but it was not found (Libv8::Location::Vendor::ArchiveNotFound)
	from /Users/lyrahall/.gem/ruby/2.3.5/gems/libv8-3.16.14.13/ext/libv8/location.rb:35:in `each'
from /Users/lyrahall/.gem/ruby/2.3.5/gems/libv8-3.16.14.13/ext/libv8/location.rb:35:in
`verify_installation!'
from /Users/lyrahall/.gem/ruby/2.3.5/gems/libv8-3.16.14.13/ext/libv8/location.rb:26:in
`install!'
	from extconf.rb:7:in `<main>'
GYP_GENERATORS=make \
	build/gyp/gyp --generator-output="out" build/all.gyp \
	              -Ibuild/standalone.gypi --depth=. \
	              -Dv8_target_arch=x64 \
-S.x64  -Dv8_enable_backtrace=1 -Dv8_can_use_vfp2_instructions=true
-Darm_fpu=vfpv2 -Dv8_can_use_vfp3_instructions=true -Darm_fpu=vfpv3 -Dwerror=''
CXX(target)
/Users/lyrahall/.gem/ruby/2.3.5/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/allocation.o
CXX(target)
/Users/lyrahall/.gem/ruby/2.3.5/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/atomicops_internals_x86_gcc.o
CXX(target)
/Users/lyrahall/.gem/ruby/2.3.5/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/bignum.o

extconf failed, exit code 1

Gem files will remain installed in /Users/lyrahall/.gem/ruby/2.3.5/gems/libv8-3.16.14.13 for
inspection.
Results logged to
/Users/lyrahall/.gem/ruby/2.3.5/extensions/x86_64-darwin-17/2.3.0-static/libv8-3.16.14.13/gem_make.out

An error occurred while installing libv8 (3.16.14.13), and Bundler cannot continue.
Make sure that `gem install libv8 -v '3.16.14.13'` succeeds before bundling.

In Gemfile:
  therubyracer was resolved to 0.12.2, which depends on
    libv8