### PR TITLE
Setup CORS for /public_members API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'stripe'
 gem 'stripe_event'
 gem 'rack-canonical-host'
 gem 'aws-sdk-rails', '~> 1.0'
+gem 'rack-cors'
 
 gem 'haml-rails'
 gem 'sass-rails', '~> 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,7 @@ GEM
     rack-canonical-host (0.1.0)
       addressable
       rack (~> 1.0)
+    rack-cors (1.0.2)
     rack-test (0.6.3)
       rack (>= 1.0)
     rack_session_access (0.1.1)
@@ -395,6 +396,7 @@ DEPENDENCIES
   puma
   quiet_assets
   rack-canonical-host
+  rack-cors
   rack_session_access
   rails (~> 4.2)
   rails_12factor

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,14 @@ module Doubleunion
     I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 
     config.autoload_paths += %W(#{config.root}/lib)
+
+    # CORS – this allows doubleunion.org to request the api from javascript
+    config.middleware.insert_before 0, "Rack::Cors" do
+      allow do
+        origins '*'
+
+        resource '/public_members', :headers => :any, :methods => [:get], :max_age => 0
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows the new github pages site to fetch the members list from javascript.