### PR TITLE
Update stripe gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'rails_autolink'
 gem 'redcarpet'
 gem 'configurable_engine'
 gem 'bugsnag'
-gem 'stripe', '~> 2' # TODO upgrade this! Carefully...
+gem 'stripe', '~> 3' # TODO upgrade this! Carefully...
 gem 'stripe_event'
 gem 'rack-canonical-host'
 gem 'aws-sdk-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,8 +314,8 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    stripe (2.12.0)
-      faraday (~> 0.9)
+    stripe (3.31.1)
+      faraday (~> 0.10)
     stripe-ruby-mock (2.5.7)
       dante (>= 0.2.0)
       multi_json (~> 1.0)
@@ -399,7 +399,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers
   state_machine!
-  stripe (~> 2)
+  stripe (~> 3)
   stripe-ruby-mock
   stripe_event
   therubyracer


### PR DESCRIPTION
Changelog: https://github.com/stripe/stripe-ruby/blob/master/CHANGELOG.md
As far as I can tell there is no breaking change in major version 2->3
I ran: `bundle update stripe stripe-ruby-mock stripe_event`

> 3.0.0 - 2017-06-27
> #pay on invoice now takes params as well as opts