### PR TITLE
Add new member orientation signup link to welcome email

### DIFF
--- a/app/views/applications_mailer/approved.html.haml
+++ b/app/views/applications_mailer/approved.html.haml
@@ -7,6 +7,8 @@
 
       %p In order to confirm your membership, log into #{ link_to "the site", EXTERNAL_SITE_URL } ("Log in" is at top right) and complete the setup #{ link_to "on this page", members_user_setup_url(@user.id) }. This is where you'll give us your Google-friendly email address for our calendar and mailing list, and set up dues (or apply for a scholarship). (After you’ve done this, a membership coordinator will subscribe you to the mailing list and invite you to Slack. Feel free to start a thread introducing yourself and jump into conversations right away!)
 
+      %p Please also sign up for a #{ link_to "New Member Orientation", ORIENTATION_SIGNUP_URL } so we can get you set up with your own access to the space!
+
       %p If you want to be listed publicly as a member (at the bottom of #{ link_to "this page", MEMBERSHIP_URL }), #{ link_to "log in", login_url } to the app and go to "Edit profile" in the right dropdown menu. There's a checkbox there marked "Show name/website/gravatar on public site?"
 
       %p After you fill out #{ link_to "the membership confirmation and setup form", members_user_setup_url(@user.id) }, here are some things the membership coordinators will do for you:

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -21,6 +21,7 @@ EXTERNAL_SITE_URL    = "https://www.doubleunion.org"
 BASE_ASSUMPTIONS_URL = EXTERNAL_SITE_URL + "/base_assumptions"
 POLICIES_URL         = EXTERNAL_SITE_URL + "/policies"
 MEMBERSHIP_URL       = EXTERNAL_SITE_URL + "/membership"
+ORIENTATION_SIGNUP_URL = "https://www.eventbrite.com/e/new-member-orientation-summer-2019-tickets-63172051306"
 
 KEY_PICKUP_DOC       = "https://docs.google.com/document/d/1RYzqGjmA3lLhv9eQzHBg82NVNjik4w_kxi8sKP5ivaY/edit?usp=sharing"
 LOCK_UP_DOC          = "https://docs.google.com/document/d/1rFoyl5FJjDdr0LqiVacQPuKyj_rsmPpOnAGc77cWTAQ/edit?usp=sharing"


### PR DESCRIPTION
I would prefer to make this configurable using something like `Configurable[:accepting_applications]` but I don't have much time right now for testing and I am sure that this will work. 