### PR TITLE
Fix stripe name and email record

### DIFF
--- a/app/controllers/members/dues_controller.rb
+++ b/app/controllers/members/dues_controller.rb
@@ -45,7 +45,8 @@ class Members::DuesController < Members::MembersController
 
     else
       stripe_customer = Stripe::Customer.create(
-        email: params[:email],
+        email: @user.email,
+        name: @user.name,
         plan: params[:plan],
         source: params[:token]
       )


### PR DESCRIPTION
We weren't properly recording member's name and email in stripe which makes it difficult to properly identify who needs a donation receipt. We'll now keep this information up-to-date and I've run a backfill to populate the correct info for existing stripe customers.