### PR TITLE
Add test coverage, fix dependencies, improve readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ arooo.iml
 
 # Don't need byebug history
 .byebug_history
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,4 @@ addons:
 before_script:
   - cp config/database.travis.yml config/database.yml
   - psql -c 'create database doubleunion_test;' -U postgres
-env:
-  - SECRET_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  - CODECOV_TOKEN="c5a54b10-ded7-4898-a613-1a70b0831d85"
+env: SECRET_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ script:
   - bundle exec rake db:create
   - bundle exec rake db:migrate
   - bundle exec rake db:test:prepare
-  - bundle exec rspec spec
+  - bundle exec rake spec
 addons:
   chrome: stable
 before_script:
   - cp config/database.travis.yml config/database.yml
   - psql -c 'create database doubleunion_test;' -U postgres
-env: SECRET_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+env:
+  - SECRET_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  - CODECOV_TOKEN="c5a54b10-ded7-4898-a613-1a70b0831d85"

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development, :test do
   gem 'rack_session_access'
   gem 'pry-rails'
   gem 'pry'
-  gem 'puma' # for capybara
+  gem 'puma', '~>3' # TOD upgrading to 4 breaks the capybara tests- fix this
   gem 'timecop'
 end
 
@@ -61,7 +61,7 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'chromedriver-helper'
+  gem 'webdrivers'
   gem 'database_cleaner'
   gem 'email_spec'
   gem 'factory_bot_rails', '~> 4'
@@ -70,4 +70,5 @@ group :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'stripe-ruby-mock', :require => 'stripe_mock'
+  gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
     annotate (3.0.2)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 13.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (6.0.4)
     autoprefixer-rails (9.6.0)
       execjs
@@ -89,11 +87,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    childprocess (1.0.1)
-      rake (< 13.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
+    childprocess (3.0.0)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -111,6 +105,7 @@ GEM
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
+    docile (1.3.2)
     email_spec (2.2.0)
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
@@ -151,7 +146,6 @@ GEM
     htmlentities (4.3.4)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     jmespath (1.4.0)
@@ -193,7 +187,7 @@ GEM
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    nokogiri (1.10.5)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)
@@ -223,7 +217,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (3.1.0)
-    puma (3.12.3)
+    puma (3.12.4)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.12)
@@ -296,7 +290,7 @@ GEM
     rspec-support (3.8.2)
     ruby_parser (3.13.1)
       sexp_processor (~> 4.9)
-    rubyzip (1.3.0)
+    rubyzip (2.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -311,12 +305,16 @@ GEM
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
-    selenium-webdriver (3.142.3)
-      childprocess (>= 0.5, < 2.0)
-      rubyzip (~> 1.2, >= 1.2.2)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sexp_processor (4.12.1)
     shoulda-matchers (4.1.0)
       activesupport (>= 4.2.0)
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -355,6 +353,10 @@ GEM
     unicorn (5.5.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    webdrivers (4.3.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -371,7 +373,6 @@ DEPENDENCIES
   bootstrap-sass
   bugsnag
   capybara
-  chromedriver-helper
   coffee-rails
   configurable_engine
   database_cleaner
@@ -394,7 +395,7 @@ DEPENDENCIES
   protected_attributes
   pry
   pry-rails
-  puma
+  puma (~> 3)
   quiet_assets
   rack-canonical-host
   rack-cors
@@ -408,6 +409,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   shoulda-matchers
+  simplecov
   state_machine!
   stripe (~> 3)
   stripe-ruby-mock
@@ -418,6 +420,7 @@ DEPENDENCIES
   turbolinks
   uglifier
   unicorn
+  webdrivers
 
 RUBY VERSION
    ruby 2.5.7p206

--- a/README.md
+++ b/README.md
@@ -38,65 +38,28 @@ We have a mailing list! Feel free to ask any question, including basic git and r
 
 If you are new to GitHub, you can [use this guide](http://railsbridge.github.io/bridge_troll/) for help making a pull request.
 
-1. Fork it
-1. Get it running
-1. Create your feature branch
-
-  ```
-  git checkout -b my-new-feature
-  ```
-
-1. Write your code and specs
-1. Commit your changes
-
-  ```
-  git commit -am 'Add some feature'
-  ```
-
-1. Push to the branch
-
-  ```
-  git push origin my-new-feature
-  ```
-
-1. Create a new Pull Request, linking to the GitHub issue url the Pull Request is fixing in the description
-1. If you find bugs, have feature requests or questions, please file an issue.
-
-
 
 ### Development setup
 
-If you are new to Rails, follow the [RailsBridge Installfest instructions](http://installfest.railsbridge.org/installfest/) for getting your environment set up.
-- You must follow the Railsbridge Installfest instructions if you do not have `ruby`, `bundler`, or `rails` installed before continuing.
+Do the below OR if you prefer docker, see the Docker Setup section 
 
-0. Fork the repo (click the Fork button above), and clone your fork to your local machine. [Here's a GitHub tutorial](https://help.github.com/articles/fork-a-repo/) about how to do so. The Railsbridge Installfest instructions may have asked you to install a different version of Ruby, but run `rvm install 2.5.5` or whatever version switching into the cloned app tells you to use to install the correct version of Ruby.
-
-1. Run `bundle install`
-    * Bundle may fail on pg; run `brew install postgresql` if it does
-    * If you get `FATAL: role “postgres” does not exist`, run `/usr/local/Cellar/postgresql/<version>/bin/createuser -s postgres`
-    * If bundle install fails with "can't find gem bundler", run `gem install bundler -v '2.0.1'` or whatever version you get from `cat Gemfile.lock | grep -A 1 "BUNDLED"`
-
-1. If you are not on OSX you may need to install postgres separately- follow https://www.postgresql.org/download/ and https://www.postgresql.org/docs/8.3/server-start.html
-
-1. Standard Rails app setup
-    * `cp config/database.example.yml config/database.yml`
-    * `rake db:create`
-    * `rake db:migrate` If for some reason you see an error like `could not find migration 3` then run `rake db:migrate VERSION=20170110040726` to force the migrations to run
-    * `rake db:test:prepare` Now you can write and run tests! You can skip the other setup steps until you want to run arooo locally. :)
-
-1. Set up an application for OAuth: http://github.com/settings/applications/new
-    * Application name: Whatever you want
-    * Homepage URL: http://localhost:3000
-    * Authorization callback URL: http://localhost:3000/auth/github/callback
-
+1. install a ruby version manager: [rvm](https://rvm.io/) or [rbenv](https://github.com/rbenv/rbenv)
+1. when you cd into the project diretory, let your version manager install the ruby version in `.ruby-version`
+1. `gem install bundler`
+1. Fork the repo (click the Fork button above), and clone your fork to your local machine. [Here's a GitHub tutorial](https://help.github.com/articles/fork-a-repo/)
+1. Make sure that postgres is installed [brew install postgres](https://wiki.postgresql.org/wiki/Homebrew) OR brew postgresql-upgrade-database (if you have an older version of postgres)
+1. `bundle install`
+1. `cp config/database.example.yml config/database.yml`
 1. `cp config/application.example.yml config/application.yml`
+1. `rake db:test:prepare` Now you can write and run tests! You can skip the other setup steps until you want to run arooo locally. :)
+1. `bundle exec rake spec # runs tests` 
+1. `bundle exec rake db:setup # requires running local postgres`
+1. `rails db:migrate`
+1. `bundle exec rake populate:users # Populate data in your local database - optional`
+1. `bundle exec rails server` # run server
+1. `bundle exec rails console` # run console (useful for looking at and changing your local data)
 
-1. Edit config/application.yml
-    * Set `GITHUB_CLIENT_KEY` and `GITHUB_CLIENT_SECRET` to the Client ID and
-      Client Secret from your Github application
-    * Don't forget to restart your Rails server so it can see your shiny new GitHub key & secret
-
-#### Docker setup
+#### Docker setup (optional)
 
 1. Install docker and docker compose
 
@@ -112,30 +75,37 @@ If you are new to Rails, follow the [RailsBridge Installfest instructions](http:
 1. setup DB
 ```docker-compose run --rm app bundle exec rake db:setup```
 
+#### Set up an application for local OAuth: 
+
+1. Github
+    * http://github.com/settings/applications/new
+    * Application name: Whatever you want
+    * Homepage URL: http://localhost:3000
+    * Authorization callback URL: http://localhost:3000/auth/github/callback
+    * in config/application.yml set `GITHUB_CLIENT_KEY` and `GITHUB_CLIENT_SECRET` to the Client ID and
+      Client Secret from your Github application
+    * Don't forget to restart your Rails server so it can see your shiny new GitHub key & secret
+1. Google
+    * TODO: figure this out and write it down 
+
+#### Common errors
+
+1. If you see the error `FATAL: role “postgres” does not exist`, if you are on OSX with brew run `/usr/local/Cellar/postgresql/<version>/bin/createuser -s postgres`
+
 ### Tests
 
 Tests, also known as specs, are great! Adding tests is a great pull request all on its own. Please try to write tests when you add or change functionality. 
 
 Run `rake db:test:prepare` after you pull or make any changes to the app, generally.
 
-Make sure `bundle exec rspec` passes before pushing your changes. (Our TravisCI integration will double-check before we merge code, so it's ok if you forget sometimes) :)
+Make sure `bundle exec rails spec` passes before pushing your changes. (Our TravisCI integration will double-check before we merge code, so it's ok if you forget sometimes) :)
 
-
-### Populate data in your local database
-
-To add a bunch of users to your dev database, you can use `bundle exec rake
-populate:users`. They will have random states. This is useful when you are running arooo locally to find a bug or look at your changes.
-
-### Rails console - local
-
-Development: `$ bundle exec rails console`
-This helps you look at and change your local data, which is helpful when you are running arooo locally to look at your changes.
+If you want to add a new kind of tests, or refactor the existing tests, do it!
 
 ### User states
 
-The current User state machine can be found in `app/models/user.rb`, but since
-it probably won't change much and it's the main moving piece of the
-application, here's a quick summary.
+The current User state machine can be found in `app/models/user.rb` It is the main moving piece of the
+application.
 
 Valid states:
 
@@ -170,16 +140,9 @@ Now you can update any user:
 > user.update_attribute(:state, 'applicant') # bypasses normal checks & succeeds
 ```
 
-If you need to make or unmake an admin, have a current admin click the un/make admin button on a member in the Member Admin View, or run the below in prod console.
+If you need to make or unmake an admin, have a current admin click the un/make admin button on a member in the Member Admin View. Admins can accept/reject applications, update any member's status, see current member's dues, open and close applications, and manage new member setup.
 
-```
-> user = User.find_by_username('cool_user')
-> user.update_attributes(is_admin: true)
-```
-
-Admins can accept/reject applications, update any member's status, see current member's dues, open and close applications, and manage new member setup.
-
-## Prod maintainer guide
+## Production maintainer / SRE guide
 You don't need this stuff if you don't have heroku permission to deploy arooo
 
 ### Rails console - heroku

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,10 @@
 #!/usr/bin/env ruby
+if ENV['RAILS_ENV'] == 'test'
+  require 'simplecov'
+  SimpleCov.start 'rails'
+  puts "required simplecov"
+end
+
 APP_PATH = File.expand_path('../../config/application',  __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'simplecov'
+SimpleCov.start
+
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'


### PR DESCRIPTION
Add test coverage, fix dependencies, improve readme


Your bundle is locked to puma (3.12.3), but that version could not
be found in any of the sources listed in your Gemfile. If you
haven't changed sources, that means the author of puma (3.12.3) has
removed it. You'll need to update your bundle to a version other
than puma (3.12.3) that hasn't been removed in order to install.

https://github.com/colszowka/simplecov

Selenium::WebDriver::Error::SessionNotCreatedError:
       session not created: This version of ChromeDriver only supports Chrome version 76
NOTICE: This gem is out of support as of 2019-03-31
Please use https://github.com/titusfortner/webdrivers instead.
See https://github.com/flavorjones/chromedriver-helper/issues/83 for details.

<img width="1657" alt="Screen Shot 2020-04-23 at 7 00 36 PM" src="https://user-images.githubusercontent.com/578159/80167493-65a2a280-8595-11ea-96d0-b9a1db5bfe30.png">
