### PR TITLE
Add Procfile to enable automatically running migrations on deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,6 @@
+web: bundle exec rails server
+
+# Commands for Heroku's "release" phase. These get run after the app is built, but
+# before the new app version is deployed to users. For details, see:
+# https://devcenter.heroku.com/articles/release-phase
+release: bundle exec rake db:migrate


### PR DESCRIPTION
### What does this code do, and why?

This PR adds a Procfile in order to:
* automatically run new migrations during a deploy
* enable us to do automated deploys to `staging` (which depends on automagically running migrations)
* better comply with Heroku's best practices

This resolves issues https://github.com/doubleunion/arooo/issues/428 and https://github.com/doubleunion/arooo/issues/408

### How is this code tested?

Ran the server locally with this Procfile, using:
```
$ heroku local -f Procfile 
```

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

n/a

### Are there any configuration or environment changes needed?

After this PR is merged, I will enable, for `staging` only, the option to automatically deploy from `master`, after CI passes.