### PR TITLE
Pass PORT to server in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: bundle exec rails server
+web: bundle exec rails server -p $PORT
 
 # Commands for Heroku's "release" phase. These get run after the app is built, but
 # before the new app version is deployed to users. For details, see:


### PR DESCRIPTION
### What does this code do, and why?

This PR fixes the Procfile added in https://github.com/doubleunion/arooo/pull/462 to pass Heroku's server port to our Rails server. Failure to do so prevents the server from starting up, as it is trying to bind to its default port, which is typically not available on Heroku.

From failed `staging` deploy with broken Procfile:
```
Jul 12 17:29:18 doubleunion-staging app/web.1 [2020-07-12 17:29:18] INFO  WEBrick 1.6.0
Jul 12 17:29:18 doubleunion-staging app/web.1 [2020-07-12 17:29:18] INFO  ruby 2.7.1 (2020-03-31) [x86_64-linux]
Jul 12 17:29:18 doubleunion-staging app/web.1 [2020-07-12 17:29:18] INFO  WEBrick::HTTPServer#start: pid=4 port=3000
Jul 12 17:30:13 doubleunion-staging heroku/web.1 Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch
Jul 12 17:30:13 doubleunion-staging heroku/web.1 Stopping process with SIGKILL
```

### How is this code tested?

Tested locally with `heroku local -f Procfile`.

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

n/a

### Are there any configuration or environment changes needed?

n/a