### PR TITLE
Add /lib to eager-loaded paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module Doubleunion
     # explicitly loading locales so they will be available in the initializers
     I18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
 
+    config.eager_load_paths += %W[#{config.root}/lib]
     config.autoload_paths += %W[#{config.root}/lib]
 
     # CORS – this allows doubleunion.org to request the api from javascript


### PR DESCRIPTION
### What does this code do, and why?

Add `lib/` to eager-loaded paths, to make the code in this directory available in production and staging. This is a follow-up for the Rails upgrade in PR https://github.com/doubleunion/arooo/pull/441 -- apparently `/lib` is no longer eager-loaded by default by Rails.

### How is this code tested?

Tested on `staging`, and locally.

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

n/a

### Are there any configuration or environment changes needed?

n/a
