### PR TITLE
Port du-doorbell endpoint implementation into Aroo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem "coffee-rails"
 gem "bootstrap-sass"
 gem "jquery-datatables-rails"
 gem "bigdecimal", "1.4.4" # specify this directly to get around the error NoMethodError: undefined method `new' for BigDecimal:Class
+gem "twilio-ruby"
+gem "redis" # Used to store recently-authorized doorbell member
 
 group :development do
   gem "annotate" # Show db schema as comments in models

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,7 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redcarpet (3.4.0)
+    redis (4.2.1)
     ref (2.0.0)
     regexp_parser (1.7.0)
     rexml (3.2.4)
@@ -377,6 +378,10 @@ GEM
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
+    twilio-ruby (5.39.2)
+      faraday (>= 0.9, < 2.0)
+      jwt (>= 1.5, <= 2.5)
+      nokogiri (>= 1.6, < 2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -440,6 +445,7 @@ DEPENDENCIES
   rails_12factor
   rails_autolink
   redcarpet
+  redis
   rspec-collection_matchers
   rspec-rails
   sass-rails
@@ -455,6 +461,7 @@ DEPENDENCIES
   thin
   timecop
   turbolinks
+  twilio-ruby
   uglifier
   unicorn
   webdrivers

--- a/README.md
+++ b/README.md
@@ -193,7 +193,9 @@ If you need to make or unmake an admin, have a current admin click the un/make a
 
 ### Programmatic doorbell
 
-Arooo includes code to handle incoming voice calls and text messages from an intercom system. This allows members to enter a personalized door code to open the door to our space. This bulk of this code is a Twilio TwiML app that lives in the [DoorbellController](app/controllers/doorbell_controller.rb).
+Arooo includes code to handle incoming voice calls and text messages from an intercom system. This allows members to enter a personalized door code to open the door to our space.
+
+This code is a [Twilio TwiML](https://www.twilio.com/docs/voice/twiml) app that lives in the [DoorbellController](app/controllers/doorbell_controller.rb).
 
 ## Production maintainer / SRE guide
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
   - [Rails console - heroku](#rails-console---heroku)
   - [Bugsnag](#bugsnag)
   - [Deploying and Heroku access](#deploying-and-heroku-access)
+  - [Environment variable configuration](#environment-variable-configuration)
   - [Email](#email)
-    - [Staging](#staging)
-  - [Email](#email-1)
+  - [Staging](#staging)
 - [Security](#security)
 - [License](#license)
 
@@ -71,7 +71,7 @@ Do the below OR if you prefer docker, see the Docker Setup section
 1. `gem install bundler`
 1. Fork the repo (click the Fork button above), and clone your fork to your local machine. [Here's a GitHub tutorial](https://help.github.com/articles/fork-a-repo/)
 1. Make sure that postgres is installed [brew install postgres](https://wiki.postgresql.org/wiki/Homebrew) OR brew postgresql-upgrade-database (if you have an older version of postgres)
-1. If you want to run the doorbell code locally, you will need to have a local instance of [Redis](https://redis.io/). You can install it on mac with `brew install redis`.
+1. If you want to run the doorbell code locally, you will need to have a local instance of [Redis](https://redis.io/). You can install it on mac with `brew install redis`. If your local Redis instance is running on a non-standard port, you can set `REDIS_URL` in your local `config/application.yaml`.
 1. `bundle install`
 1. `cp config/database.example.yml config/database.yml`
 1. `cp config/application.example.yml config/application.yml`
@@ -275,21 +275,55 @@ If you prefer to do deploys from the command line, here are the steps:
 1. If needed, perform rake tasks or set ENV variable settings on `production`
 
 
+### Environment variable configuration
+
+As of July 2020, the environment variables set in Arooo's production environment are:
+
+```
+AWS_ACCESS_KEY_ID
+AWS_REGION
+AWS_SECRET_ACCESS_KEY
+BUGSNAG_KEY
+CANONICAL_HOST: app.doubleunion.org
+DATABASE_URL
+GITHUB_CLIENT_KEY
+GITHUB_CLIENT_SECRET
+GOOGLE_CLIENT_ID
+GOOGLE_CLIENT_SECRET
+HEROKU_POSTGRESQL_CYAN_URL
+HEROKU_POSTGRESQL_RED_URL
+HOST_URL: app.doubleunion.org
+LANG: en_US.UTF-8
+MANDRILL_API_KEY
+MANDRILL_USERNAME
+NEW_RELIC_KEY
+NEW_RELIC_LICENSE_KEY
+NEW_RELIC_LOG
+RACK_ENV: production
+RAILS_ENV: production
+REDIS_URL
+SECRET_TOKEN
+STRIPE_PUBLISHABLE_KEY
+STRIPE_SECRET_KEY
+STRIPE_SIGNING_SECRET
+```
+
+You can get the current values from Heroku, either via the web UI, under Settings > Reveal Config Vars, or using the Heroku CLI: `heroku config --app du-aroo`.
+
+In your local development environment, you can set these variables in `config/application.yaml`.
+
+TODO: It would be great to document these variables further, and figure out which ones are still needed.
+
 ### Email
 
-This app sends emails via AWS: TODO more info here
+This app sends emails via AWS: TODO more info here (we also have env variables set for Mandrill, are these still needed?)
 
 
-#### Staging
+### Staging
 
 Currently neither github nor google auth works on staging- we should get this working again so we can actually test.
 
 The basic-auth login is found in https://dashboard.heroku.com/apps/doubleunion-staging/settings under BASIC_AUTH_NAME/BASIC_AUTH_PASSWORD
-
-### Email
-
-This app sends emails, but who is our email provider? TODO
-
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [Tests](#tests)
   - [User states](#user-states)
     - [Manually changing a user's state](#manually-changing-a-users-state)
+  - [Programmatic doorbell](#programmatic-doorbell)
 - [Production maintainer / SRE guide](#production-maintainer--sre-guide)
   - [Rails console - heroku](#rails-console---heroku)
   - [Bugsnag](#bugsnag)
@@ -70,6 +71,7 @@ Do the below OR if you prefer docker, see the Docker Setup section
 1. `gem install bundler`
 1. Fork the repo (click the Fork button above), and clone your fork to your local machine. [Here's a GitHub tutorial](https://help.github.com/articles/fork-a-repo/)
 1. Make sure that postgres is installed [brew install postgres](https://wiki.postgresql.org/wiki/Homebrew) OR brew postgresql-upgrade-database (if you have an older version of postgres)
+1. If you want to run the doorbell code locally, you will need to have a local instance of [Redis](https://redis.io/). You can install it on mac with `brew install redis`.
 1. `bundle install`
 1. `cp config/database.example.yml config/database.yml`
 1. `cp config/application.example.yml config/application.yml`
@@ -188,6 +190,10 @@ Now you can update any user:
 ```
 
 If you need to make or unmake an admin, have a current admin click the un/make admin button on a member in the Member Admin View. Admins can accept/reject applications, update any member's status, see current member's dues, open and close applications, and manage new member setup.
+
+### Programmatic doorbell
+
+Arooo includes code to handle incoming voice calls and text messages from an intercom system. This allows members to enter a personalized door code to open the door to our space. This bulk of this code is a Twilio TwiML app that lives in the [DoorbellController](app/controllers/doorbell_controller.rb).
 
 ## Production maintainer / SRE guide
 

--- a/app/controllers/doorbell_controller.rb
+++ b/app/controllers/doorbell_controller.rb
@@ -1,0 +1,39 @@
+require "redis"
+require "twilio-ruby"
+
+class DoorbellController < ApplicationController
+
+  def welcome
+    response = Twilio::TwiML::VoiceResponse.new do |r|
+      name = use_authorized_member
+      if name
+        r.say message: "Welcome #{name}!", voice: 'alice'
+        r.play digits: '9'
+      else
+        r.say message: 'Due to the shelter in place order for the city of San Francisco, Double Union is closed.', voice: 'alice'
+        r.say message: 'Contact the Double Union board via email or slack if you have any questions.', voice: 'alice'
+        # r.say message: 'If you are a guest or a member without a keycode, stay on the line.', voice: 'alice'
+        # r.say message: 'If you are a member with a keycode, text it to 415-214-8843 and try again.', voice: 'alice'
+        # r.dial do |dial|
+        #   dial.number('+14154890104')
+        # end
+      end
+    end
+    render xml: response.to_xml
+  end
+
+  private
+  # records the last authorized member for 2 minutes, or until the door is opened
+  def record_authorized_member(member)
+    redis = Redis.new(url: ENV['REDIS_URL'])
+    redis.set('member', member, ex: 120)
+  end
+
+  # fetches and deletes the last authorized member
+  def use_authorized_member
+    redis = Redis.new(url: ENV['REDIS_URL'])
+    member = redis.get('member')
+    redis.del('member') if member
+    member
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,4 +64,11 @@ Rails.application.routes.draw do
   get "configurations" => "api#configurations"
 
   mount StripeEvent::Engine => "/stripe"
+
+  scope path: "doorbell", as: "doorbell", defaults: { format: "xml" } do
+    root to: "doorbell#welcome"
+    # get "sms" => "doorbell#sms"
+    # get "gather-ismember" => "doorbell#gather_ismember"
+    # get "gather-keycode" => "doorbell#gather_keycode"
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,10 +65,11 @@ Rails.application.routes.draw do
 
   mount StripeEvent::Engine => "/stripe"
 
+  # Programmatic doorbell handling routes. Scoped under /doorbell path.
   scope path: "doorbell", as: "doorbell", defaults: { format: "xml" } do
     root to: "doorbell#welcome"
     get "sms" => "doorbell#sms"
-    # get "gather-ismember" => "doorbell#gather_ismember"
-    # get "gather-keycode" => "doorbell#gather_keycode"
+    get "gather-ismember" => "doorbell#gather_ismember"
+    get "gather-keycode" => "doorbell#gather_keycode"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
 
   scope path: "doorbell", as: "doorbell", defaults: { format: "xml" } do
     root to: "doorbell#welcome"
-    # get "sms" => "doorbell#sms"
+    get "sms" => "doorbell#sms"
     # get "gather-ismember" => "doorbell#gather_ismember"
     # get "gather-keycode" => "doorbell#gather_keycode"
   end

--- a/spec/controllers/doorbell_controller_spec.rb
+++ b/spec/controllers/doorbell_controller_spec.rb
@@ -108,5 +108,36 @@ describe DoorbellController do
         expect(xml.at("Gather").attribute("action").value).to eq(doorbell_gather_keycode_path)
       end
     end
-   end
+  end
+
+  describe "#gather_keycode" do
+    let(:door_code) { create(:door_code) }
+    let(:key_code) { door_code.code }
+
+    subject { get :gather_keycode, params: { SpeechResult: key_code } }
+
+    context "with valid keycode" do
+      it "welcomes the member" do
+        subject
+        xml = Nokogiri::XML(response.body)
+        expect(xml.search("Say").first.text).to include(door_code.user.name)
+      end
+
+      it "plays the digit 9" do
+        subject
+        xml = Nokogiri::XML(response.body)
+        expect(xml.at("Play").attribute("digits").value).to eq("9")
+      end
+    end
+
+    context "with invalid keycode" do
+      let(:key_code) { "what is this i can't even" }
+
+      it "redirects to gather keycode" do
+        subject
+        xml = Nokogiri::XML(response.body)
+        expect(xml.at("Gather").attribute("action").value).to eq(doorbell_gather_keycode_path)
+      end
+    end
+  end
 end

--- a/spec/controllers/doorbell_controller_spec.rb
+++ b/spec/controllers/doorbell_controller_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe DoorbellController do
   let(:redis_double) { double(Redis) }
+
   before do
     allow(Redis).to receive(:new).and_return(redis_double)
     allow(redis_double).to receive(:set)
@@ -36,7 +37,42 @@ describe DoorbellController do
       it "plays the digit 9" do
         subject
         xml = Nokogiri::XML(response.body)
-        expect(xml.search("Play").first.attribute("digits").value).to eq("9")
+        expect(xml.at("Play").attribute("digits").value).to eq("9")
+      end
+    end
+  end
+
+  describe "#sms" do
+    let(:door_code) { create(:door_code) }
+    let(:key_code) { door_code.code }
+
+    subject { get :sms, params: { Body: key_code } }
+
+    context "with an invalid keycode" do
+      let(:key_code) { "bogus_code" }
+
+      it "responds with a generic message" do
+        subject
+        xml = Nokogiri::XML(response.body)
+        expect(xml.at("Message").text).to include("is closed")
+      end
+
+      it "does not record any authorized member in Redis" do
+        expect(redis_double).not_to receive(:set)
+        subject
+      end
+    end
+
+    context "with a valid keycode" do
+      it "records the authorized member in Redis" do
+        expect(redis_double).to receive(:set).with("member", door_code.user.name, ex: 120)
+        subject
+      end
+
+      it "responds with a message to dial 111" do
+        subject
+        xml = Nokogiri::XML(response.body)
+        expect(xml.at("Message").text).to include("Dial 111")
       end
     end
   end

--- a/spec/controllers/doorbell_controller_spec.rb
+++ b/spec/controllers/doorbell_controller_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe DoorbellController do
+  let(:redis_double) { double(Redis) }
+  before do
+    allow(Redis).to receive(:new).and_return(redis_double)
+    allow(redis_double).to receive(:set)
+    allow(redis_double).to receive(:del)
+    allow(redis_double).to receive(:get).and_return(nil)
+  end
+
+  describe "#welcome" do
+    subject { get :welcome }
+    context "without a recently authorized member name" do
+      it "responds with a default welcome message" do
+        subject
+        xml = Nokogiri::XML(response.body)
+        expect(xml.search("Say").count).to eq(2)
+        expect(xml.search("Say").first.text).to include("Double Union")
+      end
+    end
+
+    context "with a recently authorized member name" do
+      let!(:member_name) { "Ariel" }
+
+      before do
+        allow(redis_double).to receive(:get).and_return(member_name)
+      end
+
+      it "welcomes the member" do
+        subject
+        xml = Nokogiri::XML(response.body)
+        expect(xml.search("Say").first.text).to include(member_name)
+      end
+
+      it "plays the digit 9" do
+        subject
+        xml = Nokogiri::XML(response.body)
+        expect(xml.search("Play").first.attribute("digits").value).to eq("9")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What does this code do, and why?

This PR moves the implementation of the doorbell endpoints from a separate app into Aroo. This is one of the steps in the work for https://github.com/doubleunion/arooo/issues/360 .

The code is largely untouched (including temporarily commented-out code and such), except for changes to adapt Sinatra code to Rails, and changing from using a keycode dictionary to querying our database.

### How is this code tested?

Unittests. Light manual testing locally to verify that XML responses seem correct.

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

n/a

### Are there any configuration or environment changes needed?

Yes. Arooo now depends on having a Redis instance available to make the doorbell code work. I have already provisioned a free Heroku Redis on both our staging and production environments.