### PR TITLE
Add simple UI to show key members their door code

### DIFF
--- a/app/views/members/users/index.html.haml
+++ b/app/views/members/users/index.html.haml
@@ -8,6 +8,15 @@
 
 = render 'bookmarks'
 
+- if current_user.key_member?
+  - if current_user.door_code
+    %p Your door code is: #{current_user.door_code.code} 🔑
+  - else
+    %p
+      You don't seem to have a door code set. Please contact
+      =mail_to "membership@doubleunion.com"
+      for help.
+
 - if @all_members.any?
   %h3 Members
   = render partial: 'list', locals: { users: @all_members }

--- a/spec/features/members_home_spec.rb
+++ b/spec/features/members_home_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe "Members home" do
+  before do
+    page.set_rack_session(user_id: member.id)
+  end
+
+  context "when logged in as a key member" do
+    let(:member) { create :key_member }
+
+    it "if they have no door code, tells them to email membership@" do
+      visit members_root_path
+      expect(page).to have_content "don't seem to have a door code"
+      expect(page).to have_content "membership@doubleunion.com"
+    end
+
+    it "if they have a door code, it is shown" do
+      door_code = create(:door_code, user: member)
+      visit members_root_path
+      expect(page).to have_content "Your door code"
+      expect(page).to have_content door_code.code
+    end
+  end
+
+  context "when logged in as a non-key-member" do
+    let(:member) { create :member }
+
+    it "does not show content about the door code" do
+      visit members_root_path
+      expect(page).to_not have_content "door code"
+    end
+  end
+end


### PR DESCRIPTION
### What does this code do, and why?

As part of the work on https://github.com/doubleunion/arooo/issues/360, this PR adds a simple UI on the members home page (`/members`) to show them their current door code. The new UI has the following states:
* If the user is not a key member, nothing about the door code is shown.
* If the user is a key member, but the database has no door code for them, show them a message about contacting the membership coordinator. (This case should never happen, once we are done with everything, but added it just to be safe.)
* If the user is a key member and we have a door code, show it to them.

Feedback on tweaks to make the UI less janky are very welcome. 😉 

### How is this code tested?

Tested on local server. Also tested in a spec.

### Are any database migrations required by this change?

No!

### Screenshots (before/after)

**Before change (and also for non-keymembers)**
<img width="1030" alt="Screen Shot 2020-07-23 at 12 36 51 PM" src="https://user-images.githubusercontent.com/6729309/88333548-48d95080-cce5-11ea-88e9-73e822d85503.png">

**Key member with no door code**
<img width="1131" alt="Screen Shot 2020-07-23 at 12 48 37 PM" src="https://user-images.githubusercontent.com/6729309/88333884-c8671f80-cce5-11ea-935e-9f88fa1cd7f5.png">

**Key member with door code**
<img width="1097" alt="Screen Shot 2020-07-23 at 12 50 56 PM" src="https://user-images.githubusercontent.com/6729309/88333716-8ccc5580-cce5-11ea-9bde-d06ebd47bbfb.png">

### Are there any configuration or environment changes needed?

No.