### PR TITLE
Update the DoorBellController to only allow entry if a door code is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ Production: `$ heroku run rails console --remote production`
 
 ### Bugsnag
 [www.bugsnag.com](https://www.bugsnag.com) is a heroku plugin that records errors in the production app. This is helpful for debugging. For bugsnag access, ask someone with access to the board@ section of 1Password to log into bugsnag and send you an email invite to create an account.
-Thank you to Bugsnag for their [OSS program](https://www.bugsnag.com/open-source) :) ![bugsnag logo](https://global-uploads.webflow.com/5c741219fd0819540590e785/5c741219fd0819856890e790_asset%2039.svg)
+Thank you to Bugsnag for their [OSS program](https://www.bugsnag.com/open-source) :)
 
-
+<img src="https://global-uploads.webflow.com/5c741219fd0819540590e785/5c741219fd0819856890e790_asset%2039.svg" width="250" />
 
 ### Deploying and Heroku access
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ Arooo includes code to handle incoming voice calls and text messages from an int
 
 This code is a [Twilio TwiML](https://www.twilio.com/docs/voice/twiml) app that lives in the [DoorbellController](app/controllers/doorbell_controller.rb).
 
+You can test the doorbell endpoints directly from a browser or using CURL. You can pass parameters to each endpoint direclty as query params. For example, to manually test the SMS endpoint:
+```
+http://localhost:3000/doorbell/sms?Body=123456
+```
+
 ## Production maintainer / SRE guide
 
 ### Rails console - heroku

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - [User states](#user-states)
     - [Manually changing a user's state](#manually-changing-a-users-state)
   - [Programmatic doorbell](#programmatic-doorbell)
+    - [Manual doorbell testing](#manual-doorbell-testing)
 - [Production maintainer / SRE guide](#production-maintainer--sre-guide)
   - [Rails console - heroku](#rails-console---heroku)
   - [Bugsnag](#bugsnag)
@@ -193,9 +194,13 @@ If you need to make or unmake an admin, have a current admin click the un/make a
 
 ### Programmatic doorbell
 
-Arooo includes code to handle incoming voice calls and text messages from an intercom system. This allows members to enter a personalized door code to open the door to our space.
+Arooo includes code to handle incoming voice calls and text messages from an intercom system, allowing members to enter a personalized door code to open the door to our space. It is implemented as a [Twilio TwiML](https://www.twilio.com/docs/voice/twiml) app that lives in the [DoorbellController](app/controllers/doorbell_controller.rb).
 
-This code is a [Twilio TwiML](https://www.twilio.com/docs/voice/twiml) app that lives in the [DoorbellController](app/controllers/doorbell_controller.rb).
+A door code is represented by the [DoorCode](app/models/door_code.rb) model, which has to be associated to a `User` in the database. Typically, the `User` should have state `key_member`.
+
+For exceptional cases (e.g. package delivery) that don't fit the "one door code per member" model, you can associate a `DoorCode` to a dummy `User` object that is in the `visitor` state. You'll have to create the dummy `User` object and doorcode through the Rails console.
+
+#### Manual doorbell testing
 
 You can test the doorbell endpoints directly from a browser or using CURL. You can pass parameters to each endpoint direclty as query params. For example, to manually test the SMS endpoint:
 ```

--- a/app/controllers/doorbell_controller.rb
+++ b/app/controllers/doorbell_controller.rb
@@ -108,7 +108,7 @@ class DoorbellController < ApplicationController
   # Gets a User object based on a keycode.
   # Returns nil if no matching code was found.
   def get_user_by_code(keycode)
-    door_code = DoorCode.find_by(code: keycode)
+    door_code = DoorCode.enabled.find_by(code: keycode)
     return nil unless door_code
 
     return door_code.user

--- a/app/models/door_code.rb
+++ b/app/models/door_code.rb
@@ -6,6 +6,8 @@ class DoorCode < ApplicationRecord
 
   validates :code, presence: true
   validates_uniqueness_of :code, case_sensitive: false
+
+  scope :enabled, -> { where(enabled: true) }
 end
 
 # == Schema Information

--- a/spec/models/door_code_spec.rb
+++ b/spec/models/door_code_spec.rb
@@ -20,4 +20,17 @@ describe DoorCode do
       expect(new_door_code.enabled).to be false
     end
   end
+
+  describe ".enabled" do
+    let!(:disabled_code) { create(:door_code, enabled: false)}
+    let!(:enabled_code) { create(:door_code, enabled: true)}
+
+    it "includes enabled doorcodes" do
+      expect(DoorCode.enabled).to include(enabled_code)
+    end
+
+    it "does not include disabled doorcodes" do
+      expect(DoorCode.enabled).to_not include(disabled_code)
+    end
+  end
 end


### PR DESCRIPTION
### What does this code do, and why?

This PR updates the logic that checks keycodes to only allow door entry if the provided keycode is enabled.

This change also includes improvements to the documentation about the doorbell, including the changes that were previously in https://github.com/doubleunion/arooo/pull/470.

### How is this code tested?

Specs.

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

n/a

### Are there any configuration or environment changes needed?

No.