### PR TITLE
Provide admin UI to view and enable/disable members' door codes

### DIFF
--- a/app/controllers/admin/door_code_controller.rb
+++ b/app/controllers/admin/door_code_controller.rb
@@ -1,0 +1,19 @@
+class Admin::DoorCodeController < ApplicationController
+  before_action :ensure_admin
+
+  def disable_door_code
+    door_code = DoorCode.find(params[:id])
+    door_code.enabled = false
+    door_code.save!
+    flash[:message] = "#{door_code.user.name}'s door code is now disabled."
+    redirect_to admin_memberships_path
+  end
+
+  def enable_door_code
+    door_code = DoorCode.find(params[:id])
+    door_code.enabled = true
+    door_code.save!
+    flash[:message] = "#{door_code.user.name}'s door code is now enabled."
+    redirect_to admin_memberships_path
+  end
+end

--- a/app/views/admin/memberships/_members.html.haml
+++ b/app/views/admin/memberships/_members.html.haml
@@ -7,6 +7,7 @@
       %th Status
       %th On scholarship?
       %th.min-width-150 Dues Paid On
+      %th.min-width-150 Space access
       %th Notes
       %th Manage Status
   %tbody
@@ -37,6 +38,22 @@
               = f.submit "Mark as on scholarship", class: "btn", data: { confirm: "Are you sure? Note: This does not change the member's dues in Stripe." }
 
         %td= user.last_stripe_charge_succeeded.strftime('%b %d %Y') if user.last_stripe_charge_succeeded
+
+        %td
+          - if user.door_code
+            = "Keycode: #{user.door_code.code}"
+            = user.door_code.enabled? ? "(enabled)" : "(disabled)"
+            - if user.door_code.enabled
+              = form_for user.door_code, url: admin_disable_door_code_path(user.door_code) do |f|
+                = f.hidden_field(:id)
+                = f.submit "Disable doorcode", class: "btn", data: { confirm: "Are you sure? This keycode will no longer work." }
+            - else
+              = form_for user.door_code, url: admin_enable_door_code_path(user.door_code) do |f|
+                = f.hidden_field(:id)
+                = f.submit "Enable doorcode", class: "btn", data: { confirm: "Are you sure? This keycode will be enabled." }
+          - else
+            = "Keycode not set."
+
         %td
           = form_for :user, url: admin_save_membership_note_path, remote: true, html: { class: "js-membership-note js-membership-note-#{user.id}" } do |f|
             = f.hidden_field :id, value: user.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
     patch "memberships/:id/change_membership_state" => "memberships#change_membership_state", :as => "change_membership_state"
     patch "memberships/:id/make_admin" => "memberships#make_admin", :as => "make_admin"
     patch "memberships/:id/unmake_admin" => "memberships#unmake_admin", :as => "unmake_admin"
+    patch "door_codes/:id/disable_door_code" => "door_code#disable_door_code", :as => "disable_door_code"
+    patch "door_codes/:id/enable_door_code" => "door_code#enable_door_code", :as => "enable_door_code"
   end
 
   get "admin/new_members" => "admin#new_members"

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -14,6 +14,11 @@ namespace :populate do
       user.state = states.sample
 
       user.save
+
+      # Some parts of the app expect members to have an application with a valid processed_at date.
+      if %w[member key_member voting_member].include? user.state
+        user.application.processed_at = (1 + rand(5)).days.ago
+      end
     end
   end
   task :user, [:username, :name, :email, :state] => :environment do |t, args|

--- a/spec/controllers/admin/door_code_controller_spec.rb
+++ b/spec/controllers/admin/door_code_controller_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Admin::DoorCodeController do
+  include AuthHelper
+
+  let(:door_code) { create(:door_code) }
+  let(:params) { { id: door_code.id } }
+
+  describe 'PATCH disable_door_code' do
+    subject { patch :disable_door_code, params: params }
+
+    context 'logged in as a non-admin member' do
+      before { login_as(:member) }
+
+      it 'redirects to root' do
+        subject
+        expect(response).to redirect_to :root
+      end
+    end
+
+    context 'logged in as an admin' do
+      before { login_as(:voting_member, is_admin: true) }
+
+      it 'disables the door code' do
+        door_code.update_attributes!(enabled: true)
+        subject
+        door_code.reload
+        expect(door_code.enabled).to be false
+      end
+    end
+  end
+
+  describe 'PATCH enable_door_code' do
+    subject { patch :enable_door_code, params: params }
+
+    context 'logged in as a non-admin member' do
+      before { login_as(:member) }
+
+      it 'redirects to root' do
+        subject
+        expect(response).to redirect_to :root
+      end
+    end
+
+    context 'logged in as an admin' do
+      before { login_as(:voting_member, is_admin: true) }
+
+      it 'disables the door code' do
+        door_code.update_attributes!(enabled: false)
+        subject
+        door_code.reload
+        expect(door_code.enabled).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What does this code do, and why?

As part of the migration of the doorbell code to Arooo (issue https://github.com/doubleunion/arooo/issues/360), this change gives admins a way to enable or disable members door codes. It is not the most elegant UI ever, but it works, and I think it is in a reasonably logical place in the app.

This PR also contains an unrelated change that improves the "realness" of the data generated by our `populate:users` rake task, which makes local development nicer.

### How is this code tested?

Unit tests. Manual testing on local server.

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

After:
![Kapture 2020-07-31 at 22 08 13](https://user-images.githubusercontent.com/6729309/89094610-8ccdf480-d37a-11ea-88af-5fc5f7282bd6.gif)


### Are there any configuration or environment changes needed?

