### PR TITLE
Show members if their door code is enabled or disabled

### DIFF
--- a/app/views/members/users/index.html.haml
+++ b/app/views/members/users/index.html.haml
@@ -10,7 +10,7 @@
 
 - if current_user.key_member?
   - if current_user.door_code
-    %p Your door code is: #{current_user.door_code.code} 🔑
+    %p Your door code is: #{current_user.door_code.code} #{current_user.door_code.enabled? ? "(enabled)" : "(disabled)"}
   - else
     %p
       You don't seem to have a door code set. Please contact

--- a/spec/features/members_home_spec.rb
+++ b/spec/features/members_home_spec.rb
@@ -20,6 +20,12 @@ describe "Members home" do
       expect(page).to have_content "Your door code"
       expect(page).to have_content door_code.code
     end
+
+    it "shows if the door code is disabled" do
+      door_code = create(:door_code, user: member, enabled: false)
+      visit members_root_path
+      expect(page).to have_content "#{door_code.code} (disabled)"
+     end
   end
 
   context "when logged in as a non-key-member" do


### PR DESCRIPTION
### What does this code do, and why?

This change improves how we show their door code to members, so that they can tell if it is enabled or not (and thus, supposed to be working or not).

### How is this code tested?

Specs. Manual testing on local server.

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

After this change:

![Screen Shot 2020-08-05 at 2 05 05 PM](https://user-images.githubusercontent.com/6729309/89464379-3586a600-d725-11ea-9ee9-99afdc114ee8.png)

### Are there any configuration or environment changes needed?

No.
