### PR TITLE
Disable a member's door code when they are no longer a key member

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -118,6 +118,10 @@ class User < ApplicationRecord
       user.update(voting_policy_agreement: false)
     end
 
+    after_transition on: all - [:key_member] do |user, _|
+      user.door_code.update!(enabled: false) if user.door_code
+    end
+
     state :visitor
     state :applicant
     state :member

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -70,6 +70,14 @@ describe User do
     it "should transition from member to former_member" do
       expect { subject }.to change { member.state }.from("member").to("former_member")
     end
+
+    context "when member had enabled door code" do
+      let(:door_code) { create(:door_code, enabled: true, user: member) }
+
+      it "disables the door code" do
+        expect { subject }.to change { door_code.enabled }.from(true).to(false)
+      end
+    end
   end
 
   describe "#make_member" do
@@ -86,6 +94,15 @@ describe User do
 
       it "should remove voting member agreement status" do
         expect { subject }.to change { member.voting_policy_agreement }.from(true).to(false)
+      end
+    end
+
+    context "with a key member" do
+      let(:member) { create(:key_member) }
+      let(:door_code) { create(:door_code, enabled: true, user: member) }
+
+      it "disables their door code" do
+        expect { subject }.to change { door_code.enabled }.from(true).to(false)
       end
     end
   end


### PR DESCRIPTION
### What does this code do, and why?

As one of the finishing steps on the doorbell migration (tracked in https://github.com/doubleunion/arooo/issues/360), this PR sets a member's door code to be in state `enabled: false` if the member ceases to be a key member.

### How is this code tested?

Unit tests.

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

n/a

### Are there any configuration or environment changes needed?

No.