### PR TITLE
Provide a way for admins to generate a new door code for a member

### DIFF
--- a/app/controllers/admin/door_code_controller.rb
+++ b/app/controllers/admin/door_code_controller.rb
@@ -16,4 +16,11 @@ class Admin::DoorCodeController < ApplicationController
     flash[:message] = "#{door_code.user.name}'s door code is now enabled."
     redirect_to admin_memberships_path
   end
+
+  def generate_new_for_user
+    user = User.find(params[:id])
+    door_code = DoorCode.new_for_user(user)
+    flash[:message] = "A door code was generated for #{user.name}."
+    redirect_to admin_memberships_path
+  end
 end

--- a/app/controllers/admin/door_code_controller.rb
+++ b/app/controllers/admin/door_code_controller.rb
@@ -19,7 +19,7 @@ class Admin::DoorCodeController < ApplicationController
 
   def generate_new_for_user
     user = User.find(params[:id])
-    door_code = DoorCode.new_for_user(user)
+    DoorCode.new_for_user(user)
     flash[:message] = "A door code was generated for #{user.name}."
     redirect_to admin_memberships_path
   end

--- a/app/models/door_code.rb
+++ b/app/models/door_code.rb
@@ -8,6 +8,25 @@ class DoorCode < ApplicationRecord
   validates_uniqueness_of :code, case_sensitive: false
 
   scope :enabled, -> { where(enabled: true) }
+
+  class << self
+    # @param user [User] User to assign the new doorcode to.
+    # @return [DoorCode] a newly created doorcode, assigned to the given user
+    def new_for_user(user)
+      # Find a new unused random code.
+      code = make_random_code()
+      while DoorCode.find_by(code: code)
+        code = make_random_code()
+      end
+      # Assign this random code to the user.
+      DoorCode.create!(code: code, user: user)
+    end
+
+    # @return [String] A randomly generated number of the requested length, as a string. May be zero-padded.
+    def make_random_code(digits: 6)
+      (1..digits).map{ "0123456789".chars.to_a.sample }.join
+    end
+  end
 end
 
 # == Schema Information

--- a/app/views/admin/memberships/_members.html.haml
+++ b/app/views/admin/memberships/_members.html.haml
@@ -46,13 +46,16 @@
             - if user.door_code.enabled
               = form_for user.door_code, url: admin_disable_door_code_path(user.door_code) do |f|
                 = f.hidden_field(:id)
-                = f.submit "Disable doorcode", class: "btn", data: { confirm: "Are you sure? This keycode will no longer work." }
+                = f.submit "Disable door code", class: "btn", data: { confirm: "Are you sure? This keycode will no longer work." }
             - else
               = form_for user.door_code, url: admin_enable_door_code_path(user.door_code) do |f|
                 = f.hidden_field(:id)
-                = f.submit "Enable doorcode", class: "btn", data: { confirm: "Are you sure? This keycode will be enabled." }
+                = f.submit "Enable door code", class: "btn", data: { confirm: "Are you sure? This keycode will be enabled." }
           - else
             = "Keycode not set."
+            = form_for user, url: admin_generate_door_code_path(user) do |f|
+              = f.hidden_field(:id)
+              = f.submit "Generate new door code", class: "btn", data: { confirm: "Do you want to generate a door code for #{user.name}?" }
 
         %td
           = form_for :user, url: admin_save_membership_note_path, remote: true, html: { class: "js-membership-note js-membership-note-#{user.id}" } do |f|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     patch "memberships/:id/unmake_admin" => "memberships#unmake_admin", :as => "unmake_admin"
     patch "door_codes/:id/disable_door_code" => "door_code#disable_door_code", :as => "disable_door_code"
     patch "door_codes/:id/enable_door_code" => "door_code#enable_door_code", :as => "enable_door_code"
+    patch "users/:id/generate_door_code" => "door_code#generate_new_for_user", :as => "generate_door_code"
   end
 
   get "admin/new_members" => "admin#new_members"

--- a/spec/controllers/admin/door_code_controller_spec.rb
+++ b/spec/controllers/admin/door_code_controller_spec.rb
@@ -55,4 +55,30 @@ describe Admin::DoorCodeController do
       end
     end
   end
+
+  describe 'PATCH generate_new_for_user' do
+    let(:key_member) { create(:key_member) }
+
+    subject { patch :generate_new_for_user, params: { id: key_member.id } }
+
+    context 'logged in as a non-admin member' do
+      before { login_as(:member) }
+
+      it 'redirects to root' do
+        subject
+        expect(response).to redirect_to :root
+      end
+    end
+
+    context 'logged in as an admin' do
+      before { login_as(:voting_member, is_admin: true) }
+
+      it 'creates a new door code for the user' do
+        expect(key_member.door_code).to be_nil
+        expect { subject }.to change { DoorCode.count }.by(1)
+        key_member.reload
+        expect(key_member.door_code).to_not be_nil
+      end
+    end
+  end
 end

--- a/spec/models/door_code_spec.rb
+++ b/spec/models/door_code_spec.rb
@@ -14,6 +14,32 @@ describe DoorCode do
     it { is_expected.to validate_uniqueness_of(:user).case_insensitive }
   end
 
+  describe ".new_for_user" do
+    let(:member) { create(:member) }
+
+    it "returns a persisted door code" do
+      expect(DoorCode.new_for_user(member).persisted?).to eq(true)
+    end
+
+    it "is assigned to the given user" do
+      expect(DoorCode.new_for_user(member).user).to eq(member)
+    end
+
+    it "has a 6-digit code" do
+      expect(DoorCode.new_for_user(member).code.length).to eq(6)
+    end
+  end
+
+  describe ".make_random_code" do
+    it "returns a string" do
+      expect(DoorCode.make_random_code()).to be_a String
+    end
+
+    it "returns a string of the requested length" do
+      expect(DoorCode.make_random_code(digits: 16).length).to eq(16)
+    end
+  end
+
   describe "#enabled" do
     it "is false by default" do
       new_door_code = DoorCode.create!(user: create(:user), code: "12345")


### PR DESCRIPTION
### What does this code do, and why?

This PR adds the ability for an admin to generate a new unique door code for a member, through the "Manage Members" UI.

(This work is related to issue https://github.com/doubleunion/arooo/issues/360)

### How is this code tested?

Specs. Local manual testing.

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

![Kapture 2020-08-11 at 16 24 25](https://user-images.githubusercontent.com/6729309/89958622-2e610b80-dbef-11ea-8b00-53cc0fb67e74.gif)

### Are there any configuration or environment changes needed?

No.