### PR TITLE
Add "pronounceable_name" field to User, make it editable, and have the doorbell use it

### DIFF
--- a/app/controllers/doorbell_controller.rb
+++ b/app/controllers/doorbell_controller.rb
@@ -27,10 +27,7 @@ class DoorbellController < ApplicationController
       keycode = params['Body'].strip
       member = get_user_by_code(keycode)
       if member
-        # TODO: In the original code, this name was a version of the name that was intended to be pronounceable by
-        # Twilio robot. Right now we don't have a place in the database for this "pronounceable name", so we are using
-        # the full name instead (which the robot will likely mangle).
-        record_authorized_member member.name
+        record_authorized_member get_name_to_say(member)
         r.message body: 'Access granted. Dial 111 on the keypad now to unlock the door.'
       else
         r.message body: 'Due to the shelter in place order for the city of San Francisco, Double Union is closed until April 7th. Email board@doubleunion.org if you have any questions.'
@@ -112,5 +109,12 @@ class DoorbellController < ApplicationController
     return nil unless door_code
 
     return door_code.user
+  end
+
+  # @return [String] The user's pronounceable name, if they have one, or their full name.
+  def get_name_to_say(user)
+    return user.pronounceable_name if user.pronounceable_name
+
+    user.name
   end
 end

--- a/app/controllers/members/users_controller.rb
+++ b/app/controllers/members/users_controller.rb
@@ -38,7 +38,7 @@ class Members::UsersController < Members::MembersController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email,
+    params.require(:user).permit(:name, :email, :pronounceable_name,
       :email_for_google, :dues_pledge,
       profile_attributes: profile_attributes)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -216,6 +216,7 @@ end
 #  last_stripe_charge_succeeded :datetime
 #  membership_note              :text
 #  name                         :string
+#  pronounceable_name           :string
 #  setup_complete               :boolean
 #  state                        :string           not null
 #  username                     :string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   EMAIL_PATTERN = /\A.+@.+\Z/
 
-  attr_accessible :username, :name, :email, :profile_attributes,
+  attr_accessible :username, :name, :email, :profile_attributes, :pronounceable_name,
     :application_attributes, :email_for_google, :dues_pledge, :is_scholarship, :voting_policy_agreement
 
   validates :state, presence: true

--- a/app/views/members/users/edit.html.haml
+++ b/app/views/members/users/edit.html.haml
@@ -6,13 +6,13 @@
   Profile fields are only visible to members by default and are totally
   optional.
 
-= form_for @user, url: members_user_path(@user) do |f|
+= form_for @user, url: members_user_path(@user) do |user_f|
 
-  = f.fields_for :profile do |fields|
+  = user_f.fields_for :profile do |fields|
     = fields.hidden_field :id
 
     %fieldset
-      = f.submit 'Save profile'
+      = user_f.submit 'Save profile'
 
     %fieldset
       = fields.check_box :show_name_on_site
@@ -21,16 +21,20 @@
         class: 'checkbox-label'
 
     %fieldset
-      %legend= f.label :name
-      = f.text_field :name
+      %legend= user_f.label :name
+      = user_f.text_field :name
+
+    %fieldset
+      %legend= user_f.label :pronounceable_name
+      = user_f.text_field :pronounceable_name
 
     %fieldset
       %legend= fields.label :pronouns, 'Pronouns'
       = fields.text_field :pronouns
 
     %fieldset
-      %legend= f.label :email, 'Email'
-      = f.text_field :email
+      %legend= user_f.label :email, 'Email'
+      = user_f.text_field :email
 
     %fieldset
       %legend= fields.label :twitter, 'Twitter username'
@@ -74,4 +78,4 @@
       %small * override email for #{link_to 'Gravatar', 'http://gravatar.com'}
 
   %fieldset
-    = f.submit 'Save profile'
+    = user_f.submit 'Save profile'

--- a/db/migrate/20200823002316_add_pronounceable_name_to_users.rb
+++ b/db/migrate/20200823002316_add_pronounceable_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddPronounceableNameToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :pronounceable_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_09_004913) do
+ActiveRecord::Schema.define(version: 2020_08_23_002316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 2020_07_09_004913) do
     t.datetime "last_stripe_charge_succeeded"
     t.boolean "is_scholarship", default: false
     t.boolean "voting_policy_agreement", default: false
+    t.string "pronounceable_name"
   end
 
   create_table "votes", id: :serial, force: :cascade do |t|

--- a/spec/controllers/doorbell_controller_spec.rb
+++ b/spec/controllers/doorbell_controller_spec.rb
@@ -64,7 +64,16 @@ describe DoorbellController do
     end
 
     context "with a valid keycode" do
-      it "records the authorized member in Redis" do
+      it "records the authorized member's pronounceable name in Redis" do
+        door_code.user.pronounceable_name = "Cee Jay"
+        door_code.user.save!
+        expect(redis_double).to receive(:set).with("member", door_code.user.reload.pronounceable_name, ex: 120)
+        subject
+      end
+
+      it "records the member name in Redis if they don't have a pronounceable name" do
+        door_code.user.pronounceable_name = nil
+        door_code.user.save!
         expect(redis_double).to receive(:set).with("member", door_code.user.name, ex: 120)
         subject
       end

--- a/spec/controllers/doorbell_controller_spec.rb
+++ b/spec/controllers/doorbell_controller_spec.rb
@@ -65,15 +65,13 @@ describe DoorbellController do
 
     context "with a valid keycode" do
       it "records the authorized member's pronounceable name in Redis" do
-        door_code.user.pronounceable_name = "Cee Jay"
-        door_code.user.save!
+        door_code.user.update!(pronounceable_name: "Cee Jay")
         expect(redis_double).to receive(:set).with("member", door_code.user.reload.pronounceable_name, ex: 120)
         subject
       end
 
       it "records the member name in Redis if they don't have a pronounceable name" do
-        door_code.user.pronounceable_name = nil
-        door_code.user.save!
+        door_code.user.update!(pronounceable_name: nil)
         expect(redis_double).to receive(:set).with("member", door_code.user.name, ex: 120)
         subject
       end

--- a/spec/controllers/members/users_controller_spec.rb
+++ b/spec/controllers/members/users_controller_spec.rb
@@ -62,6 +62,7 @@ describe Members::UsersController do
             user: {
               name: "FooBar TooBar",
               email: "someone2@foo.bar",
+              pronounceable_name: "Mouse",
               profile_attributes: {skills: "writing awesome tests"}
             }
           }
@@ -70,6 +71,7 @@ describe Members::UsersController do
 
           expect(user.name).to eq("FooBar TooBar")
           expect(user.email).to eq("someone2@foo.bar")
+          expect(user.pronounceable_name).to eq("Mouse")
           expect(user.profile.skills).to eq("writing awesome tests")
         end
       end


### PR DESCRIPTION
### What does this code do, and why?

This PR implements https://github.com/doubleunion/arooo/issues/477, with three pieces:
* adds a `pronounceable_name` to the `users` table
* adds `pronounceable_name` to the "Edit Profile" form, so that members can set their own pronounceable name
* changes the doorbell to use a member's pronounceable name, if there is one (fall back to the full name)

After adding this field to the `user`, I realized that we also have a `profile` table, where maybe this could have been added instead. Not sure if it matters much, but if you think that it makes more sense to have this on `profile`, let me know and I can change this PR to add `pronounceable_name` to `profile` instead of `user. 

### How is this code tested?

Specs, and local testing.

### Are any database migrations required by this change?

Yes.

### Screenshots (before/after)

After the change (and a successful form submission), the "Edit Profile" page looks like:

![Screen Shot 2020-08-22 at 6 10 21 PM](https://user-images.githubusercontent.com/6729309/90968634-5714bb00-e4a3-11ea-922a-034db3de98d0.png)


### Are there any configuration or environment changes needed?

No.
