### PR TITLE
Add explicit Stripe API version to Stripe initializer

### DIFF
--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -6,6 +6,10 @@ Rails.configuration.stripe = {
 
 Stripe.api_key = Rails.configuration.stripe[:secret_key]
 
+# You can verify which Stripe API version is in use, or upgrade it, through the
+# Stripe developer dashboard: https://dashboard.stripe.com/developers
+Stripe.api_version = '2016-02-03'
+
 StripeEvent.signing_secret = Rails.configuration.stripe[:event_signing_secret]
 
 StripeEvent.configure do |events|


### PR DESCRIPTION
### What does this code do, and why?

Fix for https://github.com/doubleunion/arooo/issues/492, to avoid developer Stripe API confusion in development.

Here is a screenshot from our Stripe dashboard to double-check that I set the correct API version:
![Screen Shot 2020-09-30 at 7 43 47 PM](https://user-images.githubusercontent.com/6729309/94759954-26ebf200-0356-11eb-8e6e-d3450e499cec.png)

(source https://dashboard.stripe.com/developers , logged in as Double Union account.)

### How is this code tested?

The specs pass, the server starts up.

### Are any database migrations required by this change?

Nope.

### Screenshots (before/after)

N/a

### Are there any configuration or environment changes needed?

No