### PR TITLE
Remove some unused development-only gems, to simplify setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,11 +39,8 @@ group :development do
   gem "better_errors" # Provides a better error page for Rails and other Rack apps
   gem "binding_of_caller" # Retrieve the binding of a method's caller
   gem "html2haml"
-  # gem "quiet_assets" # turns off Rails asset pipeline log; disabled because of Rails 5 upgrade shenanigans
   gem "awesome_print"
   gem "execjs" # last updated 2016
-  gem "therubyracer" # Call JavaScript code and manipulate JavaScript objects from Ruby
-  # gem 'rails_upgrader'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ end
 
 group :development, :test do
   gem "rspec-rails", ">= 4.0.0"
-  gem "thin"
   gem "faker"
   gem "rack_session_access"
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,6 @@ GEM
     kgio (2.11.2)
     launchy (2.5.0)
       addressable (~> 2.7)
-    libv8 (3.16.14.19)
     loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -283,7 +282,6 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.4.0)
     redis (4.2.1)
-    ref (2.0.0)
     regexp_parser (1.7.1)
     rexml (3.2.4)
     rspec-collection_matchers (1.2.0)
@@ -364,9 +362,6 @@ GEM
       activesupport (>= 3.1)
       stripe (>= 2.8, < 6)
     temple (0.8.2)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -457,7 +452,6 @@ DEPENDENCIES
   stripe (~> 3)
   stripe-ruby-mock
   stripe_event
-  therubyracer
   thin
   timecop
   turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,6 @@ GEM
     configurable_engine (0.5.0)
       rails (> 4.2.0)
     crass (1.0.6)
-    daemons (1.3.1)
     dante (0.2.0)
     database_cleaner (1.8.4)
     debug_inspector (0.0.3)
@@ -115,7 +114,6 @@ GEM
       mail (~> 2.7)
     erubi (1.9.0)
     erubis (2.7.0)
-    eventmachine (1.2.7)
     execjs (2.7.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -362,10 +360,6 @@ GEM
       activesupport (>= 3.1)
       stripe (>= 2.8, < 6)
     temple (0.8.2)
-    thin (1.7.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -452,7 +446,6 @@ DEPENDENCIES
   stripe (~> 3)
   stripe-ruby-mock
   stripe_event
-  thin
   timecop
   turbolinks
   twilio-ruby

--- a/README.md
+++ b/README.md
@@ -129,16 +129,6 @@ Do the below OR if you prefer docker, see the Docker Setup section
 
 1. If you see the error `FATAL: role “postgres” does not exist`, if you are on OSX with brew run `/usr/local/Cellar/postgresql/<version>/bin/createuser -s postgres`
 2. Arooo depends on a fork of the `state_machine` gem, because the original gem is no longer maintained. Fork is at https://github.com/compwron/state_machine, original gem is https://rubygems.org/gems/state_machine_deuxito .
-3. If during `bundle install` you run into errors installing `libv8` or `therubyracer`, on Mac you can solve that with the commands below (also, see other options discussed in [this gist](https://gist.github.com/fernandoaleman/868b64cd60ab2d51ab24e7bf384da1ca)):
-```bash
-# Get the version numbers from your error output. At the time of this writing, I used:
-# libv8: '3.16.14.19'
-# therubyracer: '0.12.3'
-$ brew install v8@3.15
-$ gem install libv8 -v 'YOUR_VERSION' -- --with-system-v8
-$ gem install therubyracer -v 'YOUR_VERSION' -- --with-v8-dir=$(brew --prefix v8@3.15)
-$ bundle install
-```
 
 #### Linting
 


### PR DESCRIPTION
### What does this code do, and why?

As suggested in https://github.com/doubleunion/arooo/issues/497, this PR removes some gems that seem to be unused. (Those gems might have facilitated development workflows for some devs, however. Unclear if/when these gems were last used by someone.)

### How is this code tested?

n/a

### Are any database migrations required by this change?

No

### Screenshots (before/after)

n/a

### Are there any configuration or environment changes needed?

No