### PR TITLE
Admins displayed on members home

### DIFF
--- a/app/controllers/members/users_controller.rb
+++ b/app/controllers/members/users_controller.rb
@@ -5,6 +5,9 @@ class Members::UsersController < Members::MembersController
     @all_members = User.all_members
       .includes(:profile)
       .order_by_state
+    @all_admins = User.all_admins
+      .includes(:profile)
+      .order_by_state
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,8 @@ class User < ApplicationRecord
 
   scope :all_members, -> { where(state: %w[member key_member voting_member]) }
 
+  scope :all_admins, -> { where(is_admin: true) }
+
   scope :no_stripe_dues, -> {
     all_members
       .where(stripe_customer_id: nil)

--- a/app/views/members/users/index.html.haml
+++ b/app/views/members/users/index.html.haml
@@ -17,6 +17,11 @@
       =mail_to "membership@doubleunion.com"
       for help.
 
+- if @all_admins.any?
+  %h3 Admins
+  %p This internal DU app is administered by DU Membership Coordinators (membership@doubleunion.org) and Board Members (board@doubleunion.org), and it many also have Web App committee members supporting it. Members with admin access: 
+  = render partial: 'list', locals: { users: @all_admins }
+
 - if @all_members.any?
   %h3 Members
   = render partial: 'list', locals: { users: @all_members }


### PR DESCRIPTION
### What does this code do, and why?
#449

### How is this code tested?
Manually. 
1. Had no admins. Didn't see any admin section.
2. Made someone an admin. Saw an admin section as asked.

### Are any database migrations required by this change?
None.

### Screenshots (before/after)
before: 
<img width="1409" alt="Screenshot 2020-10-16 at 4 46 03 AM" src="https://user-images.githubusercontent.com/40358683/96195503-8a873980-0f6a-11eb-8a5b-9bdfaa9b1cf8.png">

after:
<img width="1430" alt="Screenshot 2020-10-16 at 4 41 50 AM" src="https://user-images.githubusercontent.com/40358683/96195509-8fe48400-0f6a-11eb-9960-4f980e6be8cd.png">



### Are there any configuration or environment changes needed?
None.
