### PR TITLE
[fix] Avoid 500 status error in `members::dues#show` when customer does not have a plan

### DIFF
--- a/app/controllers/members/dues_controller.rb
+++ b/app/controllers/members/dues_controller.rb
@@ -5,7 +5,7 @@ class Members::DuesController < Members::MembersController
     if current_user.stripe_customer_id
       customer = Stripe::Customer.retrieve(current_user.stripe_customer_id)
       @subscription = customer.subscriptions.first
-      @current_plan = amount_plan_name.fetch(@subscription.plan.amount, nil)
+      @current_plan = amount_plan_name.fetch(@subscription.plan.amount, nil) if @subscription
     end
   end
 

--- a/spec/controllers/members/dues_controller_spec.rb
+++ b/spec/controllers/members/dues_controller_spec.rb
@@ -15,6 +15,36 @@ describe Members::DuesController do
       subject
       expect(response).to redirect_to :root
     end
+
+    context "when a member has an associated Stripe account without a subscription" do
+      let(:current_user) do
+         login_as(
+           :member,
+           name: "Foo Bar",
+           email: "someone@example.com",
+           stripe_customer_id: 'stripe-user-id-abc123'
+         )
+      end
+
+      before do
+        StripeMock.start
+
+        Stripe::Customer.create(
+          subscriptions: [],
+          id: current_user.stripe_customer_id
+        )
+      end
+
+      after do
+        StripeMock.stop
+      end
+
+      it "renders ok" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe "DELETE cancel" do


### PR DESCRIPTION
### What does this code do, and why?

Fixes https://github.com/doubleunion/arooo/issues/504

### How is this code tested?

Controller spec

### Are any database migrations required by this change?

No

### Screenshots (before/after)

N/a

### Are there any configuration or environment changes needed?

No
