### PR TITLE
Force SSL using rails configuration for production/staging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,13 +6,6 @@ class ApplicationController < ActionController::Base
 
   before_action :set_locale
 
-
-  def redirect_https
-    return true if Rails.env.test?
-    redirect_to :protocol => "https://" unless request.ssl?
-    return true
-  end
-
   private
 
   def current_user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,9 +1,5 @@
 class SessionsController < ApplicationController
 
-  before_action :redirect_https, only: [
-    :login
-  ]
-
   def login
     redirect_to members_root_path if current_user.try(:general_member?)
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -43,7 +43,7 @@ Doubleunion::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Set to :debug to see everything in the log.
   config.log_level = :info


### PR DESCRIPTION
### What does this code do, and why?

Addresses #503 . Forces SSL in production/staging through rails configuration, removing custom logic to do that from the application controller.

### How is this code tested?

Could be deployed to staging to ensure it works as expected.

### Are any database migrations required by this change?

No

### Screenshots (before/after)

N/a

### Are there any configuration or environment changes needed?

Not apart from the included in the PR.