### PR TITLE
#475 Add error for when doorbell/sms endpoint is called without a doorcode

### DIFF
--- a/app/controllers/doorbell_controller.rb
+++ b/app/controllers/doorbell_controller.rb
@@ -23,6 +23,8 @@ class DoorbellController < ApplicationController
   end
 
  def sms
+    raise NoMethodError, 'Required doorcode was not provided' unless params['Body'].present?
+  
     response = Twilio::TwiML::MessagingResponse.new do |r|
       keycode = params['Body'].strip
       member = get_user_by_code(keycode)

--- a/spec/controllers/doorbell_controller_spec.rb
+++ b/spec/controllers/doorbell_controller_spec.rb
@@ -97,6 +97,14 @@ describe DoorbellController do
         subject
       end
     end
+    
+   context "without a doorcode" do
+      subject { get :sms }
+
+      it "should raise a NoMethodError with clearer error message" do
+        expect { subject }.to raise_error.with_message(/Required doorcode was not provided/)
+     end
+   end
   end
 
   describe "#gather_ismember" do


### PR DESCRIPTION
### What does this code do, and why?
Closes #475 
Raise error when no doorcode is provided in the param body as it would previously throw undefined method `strip' for nil:NilClass and this way it returns a more graceful error me ssage. Addded context for when "without a doorcode" it "should raise a NoMethodError with a clearer error message"

### How is this code tested?
Within `spec/controllers/doorbell_controller_spec.rb` within the sms block with context of "without a doorcode". 

### Are any database migrations required by this change?
Nope 🙂

If there is any feedback or anything that can be improved please let me know! Thanks for letting me work on this! 🎉