### PR TITLE
Clarify visibility of application

### DIFF
--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -6,7 +6,7 @@
   #{ mail_to JOIN_EMAIL }.
 
 %p
-  = "You can save this application at any time before you submit it. Once submitted, it will only be visible to Double Union members. No part of this application will ever be public."
+  = "You can save this application at any time before you submit it. Once submitted, it will be visible to all current Double Union members. No part of this application will ever be public."
 
 %p
   = "A small tip: The paragraph questions are parsed as markdown! "

--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -6,7 +6,7 @@
   #{ mail_to JOIN_EMAIL }.
 
 %p
-  = "You can save this application at any time before you submit it. Once submitted, it will be visible to all current Double Union members. No part of this application will ever be public."
+  = "You can save this application at any time before you submit it. Once submitted, the content will be readable by all current Double Union members. No part of this application will ever be public."
 
 %p
   = "A small tip: The paragraph questions are parsed as markdown! "


### PR DESCRIPTION
### What does this code do, and why?

Try to ensure we’re clear in the application process that application content will be visible to all current DU members. This is because some new members have been surprised to find out that all current members were able to view their applications during the voting process. We want to ensure that applicants are appropriately informed about what we do with their information.

### How is this code tested?

It's just a text change, no test changes needed.

### Are any database migrations required by this change?

No

### Screenshots (before/after)


### Are there any configuration or environment changes needed?

No