### PR TITLE
Remove development-only gem execjs, which seems unused

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ group :development do
   gem "binding_of_caller" # Retrieve the binding of a method's caller
   gem "html2haml"
   gem "awesome_print"
-  gem "execjs" # last updated 2016
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -420,7 +420,6 @@ DEPENDENCIES
   configurable_engine (>= 0.5.0)
   database_cleaner
   email_spec
-  execjs
   factory_bot_rails (>= 6.1.0)
   faker
   figaro


### PR DESCRIPTION
### What does this code do, and why?

Remove `execjs` gem from our `development` dependencies, because I can't find any references to it in our code, and it is giving setup troubles to a contributor.

### How is this code tested?

The specs pass.

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

n/a

### Are there any configuration or environment changes needed?

no!