### PR TITLE
Content update for application questions

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -66,8 +66,8 @@ class ApplicationsController < ApplicationController
   end
 
   def profile_attributes
-    [:id, :twitter, :pronouns, :facebook, :website, :linkedin, :blog,
-     :summary, :reasons, :feminism, :projects, :skills]
+    [:id, :twitter, :pronouns, :facebook, :website, :linkedin, :reasons,
+      :feminism, :attendance]
   end
 
   def application_attributes

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -33,6 +33,7 @@ end
 # Table name: profiles
 #
 #  id                :integer          not null, primary key
+#  attendance        :string(2000)
 #  blog              :string
 #  facebook          :string
 #  feminism          :string(2000)

--- a/app/views/applications/_show.html.haml
+++ b/app/views/applications/_show.html.haml
@@ -34,27 +34,13 @@
     %td= external_auto_link(@user.profile.linkedin)
 
   %tr
-    %td.left Blog url
-    %td= external_auto_link(@user.profile.blog)
-
-  %tr
-    %td.left Tell us a little about yourself!
-    %td= markdown(@user.profile.summary)
-
-  %tr
     %td.left Why are you interested in joining Double Union?
     %td= markdown(@user.profile.reasons)
 
   %tr
-    %td.left Tell us about your feminism! (especially how it relates to intersectionality)
+    %td.left Tell us about your feminism!
     %td= markdown(@user.profile.feminism)
 
   %tr
-    %td.left What would you like to work on in the space?
-    %td= markdown(@user.profile.projects)
-
-  %tr
-    %td.left
-      What skills are you most interested in learning, improving, and/or
-      teaching?
-    %td= markdown(@user.profile.skills)
+    %td.left Have you been to DU events or met DU members?
+    %td= markdown(@user.profile.attendance)

--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -117,7 +117,7 @@
             = "This is not needed to send in an application, but it helps us remember if we’ve met you! Please include people’s names if you can (it’s completely ok if you can’t). Or let us know if you're planning to attend an upcoming event, so we can say hi to you."
           %p.small
             = "Required — 2000 character maximum."
-        %td= profile_fields.text_area :projects, rows: 8
+        %td= profile_fields.text_area :attendance, rows: 8
 
       %tr.nested-table
         %td{ colspan: 2 }

--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -90,25 +90,9 @@
 
       %tr
         %td
-          = profile_fields.label :blog, "Blog URL"
-          %small
-            = "(optional)"
-        %td= profile_fields.text_field :blog
-
-      %tr
-        %td
-          = profile_fields.label :summary, "Tell us a little about yourself!"
-          %p.small
-            = "In this question, we're just curious to get an overall sense of your story. We don't evaluate applications based on how accomplished or successful a person is. Some sentences or a paragraph would be great; for all of these questions, we love getting to read some detail but don't want to burden you with writing a huge essay. Feel free to include extra URLs if you like. It's helpful to include a little extra info here if you don't have a public online presence (such as Twitter or a website)."
-          %p.small
-            = "Required — 2000 character maximum."
-        %td= profile_fields.text_area :summary, rows: 10
-
-      %tr
-        %td
           = profile_fields.label :reasons, "Why are you interested in joining Double Union?"
           %p.small
-            = "We ask this question since we'd like to know if you have interests and goals related to joining DU that are approximately compatible with the general broad goals of DU (and what it can offer to members)."
+            = "We ask this because we'd like to learn about how your interests relate to DU. For example, what would you like to work on here, or what would you like to learn or share here?"
           %p.small
             = "Required — 2000 character maximum."
         %td= profile_fields.text_area :reasons, rows: 10
@@ -117,30 +101,23 @@
         %td
           = profile_fields.label :reasons, "Tell us about your feminism!"
           %p.small
-            = "We ask this because we care about DU being an intersectional feminist space, and it's important to us that new members care about this too; we expect members to identify as feminist in some way. To help us understand your perspective, we'd like to hear about your thoughts around your own feminism. It's ok if you don't have a formal/academic way of talking about this! You may also find it helpful to look at our "
-            #{ link_to "base assumptions", BASE_ASSUMPTIONS_URL, target: "_blank" }
-            = " since they help explain DU's shared values."
+            = "We ask this because we care about DU being an intersectional feminist space, and it's important to us that new members care about this too."
+          %p.small
+            = "To help us understand your view, we'd like to hear about your thoughts around your own feminism. It's ok if you don't have a formal or academic way of talking about this!"
+          %p.small
+            = "If you’d like examples, we encourage you to consider these questions: How does your feminism relate to race and class? How does your feminism include transgender people? How does your feminism show up in your lived experiences and/or your philosophy?"
           %p.small
             = "Required — 2000 character maximum."
-        %td= profile_fields.text_area :feminism, rows: 10
+        %td= profile_fields.text_area :feminism, rows: 12
 
       %tr
         %td
-          = profile_fields.label :projects, "What would you like to work on in the space?"
+          = profile_fields.label :attendance, "Have you been to DU events or met DU members?"
           %p.small
-            = "We're curious! We sometimes look at these answers to help us figure out what kinds of workshops and events to hold during the membership application round (or as public events in general). This doesn't have to be long."
-          %p.small
-            = "Required — 2000 character maximum."
-        %td= profile_fields.text_area :projects, rows: 10
-
-      %tr
-        %td
-          = profile_fields.label :skills, "What skills are you most interested in learning, improving, and/or teaching?"
-          %p.small
-            = "Same as above - we're curious! This doesn't have to be long."
+            = "This is not needed to send in an application, but it helps us remember if we’ve met you! Please include people’s names if you can (it’s completely ok if you can’t). Or let us know if you're planning to attend an upcoming event, so we can say hi to you."
           %p.small
             = "Required — 2000 character maximum."
-        %td= profile_fields.text_area :skills, rows: 10
+        %td= profile_fields.text_area :projects, rows: 8
 
       %tr.nested-table
         %td{ colspan: 2 }
@@ -158,7 +135,7 @@
 
               %tr
                 %td.pt-10= app_fields.check_box :agreement_female
-                %td.pt-10.pl-10= app_fields.label :agreement_female, "#{"To keep the focus on a great space for women and nonbinary people (trans, cis, queer, straight, and not-fitting-into-those-labels), all DU members are women and nonbinary people. This fits with my self-identification."}", class: 'checkbox-label'
+                %td.pt-10.pl-10= app_fields.label :agreement_female, "#{"To keep the focus on a great space for nonbinary people and women (trans, cis, intersex, queer, straight, and not-fitting-into-those-labels), DU offers membership to women and nonbinary people. This fits with my self-identification."}", class: 'checkbox-label'
 
   - if @user.application.submitted?
     = f.submit "Update application", name: 'save', class: "btn"

--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -99,7 +99,7 @@
 
       %tr
         %td
-          = profile_fields.label :reasons, "Tell us about your feminism!"
+          = profile_fields.label :feminism, "Tell us about your feminism!"
           %p.small
             = "We ask this because we care about DU being an intersectional feminist space, and it's important to us that new members care about this too."
           %p.small

--- a/db/migrate/20201124040111_add_attendance_to_profile.rb
+++ b/db/migrate/20201124040111_add_attendance_to_profile.rb
@@ -1,0 +1,5 @@
+class AddAttendanceToProfile < ActiveRecord::Migration[6.0]
+  def change
+    add_column :profiles, :attendance, :string, limit: 2000
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_23_002316) do
+ActiveRecord::Schema.define(version: 2020_11_24_040111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,13 +56,12 @@ ActiveRecord::Schema.define(version: 2020_08_23_002316) do
   end
 
   create_table "door_codes", id: :serial, force: :cascade do |t|
-    t.integer "user_id", null: false
+    t.integer "user_id"
     t.string "code", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["code"], name: "index_door_codes_on_code", unique: true
-    t.index ["user_id"], name: "index_door_codes_on_user_id", unique: true
   end
 
   create_table "profiles", id: :serial, force: :cascade do |t|
@@ -82,6 +81,7 @@ ActiveRecord::Schema.define(version: 2020_08_23_002316) do
     t.string "skills", limit: 2000
     t.string "feminism", limit: 2000
     t.string "pronouns"
+    t.string "attendance", limit: 2000
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 

--- a/spec/features/apply_to_du_spec.rb
+++ b/spec/features/apply_to_du_spec.rb
@@ -1,54 +1,54 @@
 require "spec_helper"
 
 describe "applying to double union" do
-  let(:cool_lady) { create(:user) }
-  let(:application_state) { cool_lady.application.state }
+  let(:cool_cat) { create(:user) }
+  let(:application_state) { cool_cat.application.state }
 
   before do
-    cool_lady.update_attribute(:state, "applicant")
-    page.set_rack_session(user_id: cool_lady.id)
+    cool_cat.update_attribute(:state, "applicant")
+    page.set_rack_session(user_id: cool_cat.id)
   end
 
   it "allows the user to submit an application" do
     visit new_application_path
 
     fill_in "Twitter username", with: "@beepboopbeep"
-    fill_in "Blog URL", with: "http://blog.awesome.com"
     fill_in "Pronouns", with: "They/Them"
+    fill_in "user_profile_attributes_attendance", with: "I went to the cool thing"
     check "user_application_attributes_agreement_terms"
     check "user_application_attributes_agreement_policies"
     check "user_application_attributes_agreement_female"
 
     expect {
       click_on "Submit application"
-    }.to change { cool_lady.application.reload.state }.from("started").to("submitted")
+    }.to change { cool_cat.application.reload.state }.from("started").to("submitted")
 
     expect(page).to have_content "Application submitted!"
     expect(find_field("Pronouns").value).to eq "They/Them"
     expect(find_field("Twitter username").value).to eq "@beepboopbeep"
+    expect(find_field("user_profile_attributes_attendance").value).to eq "I went to the cool thing"
   end
 
-  it "allows the user to save her application without submitting it" do
+  it "allows the user to save their application without submitting it" do
     visit new_application_path
     expect(page).to have_content "We're glad you're interested"
 
     fill_in "Twitter username", with: "@beepboopbeep"
-    fill_in "Tell us a little about yourself!", with: "I am definitely not a cat!"
+    fill_in "user_profile_attributes_attendance", with: "I went to the cool thing"
 
     first(:button, "Save without submitting").click
 
-    expect(cool_lady.application.state).to eq("started")
+    expect(cool_cat.application.state).to eq("started")
     expect(page).to have_content "Application saved"
     expect { Application.count }.to change { Application.count }.by(0)
   end
 
-  it "allows the user to update her application" do
+  it "allows the user to update their application" do
     visit new_application_path
     expect(page).to have_content "We're glad you're interested"
 
     fill_in "Pronouns", with: "They/Them"
     fill_in "Twitter username", with: "@beepboopbeep"
-    fill_in "Blog URL", with: "http://blog.awesome.com"
     check "user_application_attributes_agreement_terms"
     check "user_application_attributes_agreement_policies"
     check "user_application_attributes_agreement_female"


### PR DESCRIPTION
### What does this code do, and why?

This updates the text of our application questions to [our revised questions](https://docs.google.com/document/d/1PZzJFyXQCgi_KQyxm8_1cegp4Ep7AX3xNl40v2Fo-XI/edit#), including removing some of the old questions and adding a new one ("Have you been to DU events or met DU members?"). The underlying goal is to lower the stress of being an applicant by removing questions that we don't need to make a decision about an application.

This is only a content change, and it needs some engineering work - I added a new "attendance" element because of the new question, but that needs to become part of the code and databases. That still seemed like a better idea than awkwardly reusing one of the elements I removed.

I also removed the "Blog URL" field because that seems a bit outdated/weird (if a person has a blog, they'd likely list it as their "Website URL" instead of as an additional URL).

I also updated the gender language slightly - to add intersex people (matching https://github.com/doubleunion/doubleunion-dot-org/pull/104) and to reflect that we're only asking if this gender language works for the applicant right now, not assuming that all members always exactly match the gender language.

* Before: "To keep the focus on a great space for women and nonbinary people (trans, cis, queer, straight, and not-fitting-into-those-labels), all DU members are women and nonbinary people. This fits with my self-identification."
* After: "To keep the focus on a great space for nonbinary people and women (trans, cis, intersex, queer, straight, and not-fitting-into-those-labels), DU offers membership to women and nonbinary people. This fits with my self-identification."

### How is this code tested?

Updated specs, also tested locally submitting and reviewing an application.

### Are any database migrations required by this change?

Yep. Added `attendance` field to `Profile`.

### Screenshots (before/after)

Before:

![Screen Shot 2020-11-23 at 5 26 13 PM](https://user-images.githubusercontent.com/391313/100034422-01f18980-2db1-11eb-9ac9-71a9383a1da0.png)
![Screen Shot 2020-11-23 at 5 26 18 PM](https://user-images.githubusercontent.com/391313/100034434-04ec7a00-2db1-11eb-912a-55d9d17acf30.png)

After:

![Screen Shot 2020-11-23 at 5 24 48 PM](https://user-images.githubusercontent.com/391313/100034315-cbb40a00-2db0-11eb-86e1-e020268125c2.png)

### Are there any configuration or environment changes needed?

Nope.