### PR TITLE
Add more meaningful message when a sponsor tries to sponsor the same application again

### DIFF
--- a/app/controllers/members/applications_controller.rb
+++ b/app/controllers/members/applications_controller.rb
@@ -26,12 +26,10 @@ class Members::ApplicationsController < Members::MembersController
 
       if sponsorship.save
         vote(application_params, true) if current_user.voting_member?
+      elsif current_user.sponsorship(application)
+        flash[:notice] = "You are already sponsoring this application!"
       else
-        if current_user.sponsorship(application)
-          flash[:notice] = "You are already sponsoring this application!"
-        else
           flash[:error] = "Sorry, something went wrong!"
-        end
       end
     else
       Sponsorship.where(user_id: current_user, application_id: application).destroy_all

--- a/app/controllers/members/applications_controller.rb
+++ b/app/controllers/members/applications_controller.rb
@@ -15,7 +15,7 @@ class Members::ApplicationsController < Members::MembersController
 
     @user = @application.user
     @vote = current_user.vote_for(@application) || Vote.new
-    @sponsorship = current_user.sponsor(@application)
+    @sponsorship = current_user.sponsorship(@application)
   end
 
   def sponsor
@@ -27,7 +27,11 @@ class Members::ApplicationsController < Members::MembersController
       if sponsorship.save
         vote(application_params, true) if current_user.voting_member?
       else
-        flash[:error] = "Sorry, something went wrong!"
+        if current_user.sponsorship(application)
+          flash[:notice] = "You are already sponsoring this application!"
+        else
+          flash[:error] = "Sorry, something went wrong!"
+        end
       end
     else
       Sponsorship.where(user_id: current_user, application_id: application).destroy_all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -187,7 +187,7 @@ class User < ApplicationRecord
     end
   end
 
-  def sponsor(application)
+  def sponsorship(application)
     Sponsorship.where(application: application, user: self).first
   end
 

--- a/spec/features/sponsorship_spec.rb
+++ b/spec/features/sponsorship_spec.rb
@@ -42,4 +42,21 @@ describe "sponsoring an applicant" do
       expect(page).not_to have_css(".is_sponsor")
     end
   end
+
+  describe "someone who is already a sponsor" do
+    before do
+      page.set_rack_session(user_id: mature_member.id)
+      visit members_application_path(application)
+      check "is_sponsor"
+      click_button "Submit"
+    end
+
+    it "gets a meaningful message if they try to sponsor again" do
+      visit members_application_path(application)
+      check "is_sponsor"
+      expect { click_button "Submit" }.to_not change(Sponsorship, :count)
+      expect(page).to_not have_content "Sorry, something went wrong!"
+      expect(page).to have_content "You are already sponsoring"
+    end
+   end
 end


### PR DESCRIPTION
### What does this code do, and why?

To address issue https://github.com/doubleunion/arooo/issues/252, this PR adds a "notice" (not an error) that says "You are already sponsoring this application!", shown to a member who is already a sponsor and tries to sponsor the same application again.

### How is this code tested?

Added a test case into the appropriate spec.

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

With this change, after submitting the "i want to sponsor" form for a second time:
![Screen Shot 2020-11-29 at 3 58 52 PM](https://user-images.githubusercontent.com/6729309/100557130-cdbc1400-325b-11eb-8aca-2da8aebe3e56.png)

### Are there any configuration or environment changes needed?

No.
