### PR TITLE
Handle more gracefully attempts to double-submit an application and rescue + report all errors

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -26,12 +26,17 @@ class ApplicationsController < ApplicationController
 
     case commit_action
     when :submit
-      begin
-        @user.application.submit!
-        flash[:notice] = "Application submitted!"
-      rescue StateMachine::InvalidTransition
-        errors = @user.application.errors.full_messages.to_sentence
-        flash[:error] = "Application not submitted: #{errors}"
+      if @user.application.submitted?
+        flash[:notice] = "Application already submitted!"
+      else
+        begin
+          @user.application.submit!
+          flash[:notice] = "Application submitted!"
+        rescue StandardError => e
+          errors = @user.application.errors.full_messages.to_sentence
+          errors = e.inspect if errors.empty?
+          flash[:error] = "Application not submitted: #{errors}"
+        end
       end
     when :save
       flash[:notice] = "Application saved"

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -198,6 +198,33 @@ describe ApplicationsController do
             expect { subject }.not_to change { application.state }.from("started")
           end
         end
+
+        context "with an already-submitted application state" do
+          before do
+            application.update(state: "submitted")
+          end
+
+          it "does not show an error" do
+            subject
+            expect(flash[:error]).to eq(nil)
+          end
+
+          it "shows an 'already submitted' notice" do
+            subject
+            expect(flash[:notice]).to include "already submitted"
+          end
+        end
+
+        context "with an unexpected error" do
+          before do
+            allow(application).to receive(:submit).and_raise("a very unexpected error")
+          end
+
+          it "shows an error message" do
+            subject
+            expect(flash[:error]).to include "very unexpected error"
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### What does this code do, and why?

This PR addresses https://github.com/doubleunion/arooo/issues/317 in two ways:
* When an applicant submits an application that is already submitted (e.g. they submitted in a different tab, or they clicked the "Submit" button twice), show a notice confirming that the application is already submitted. Don't show any errors.
* Report the error message of any error, not just the invalid state transition issues. If something really unexpected goes wrong, the error message might not be very applicant-friendly, but it might help us debug the issue if they report the problem to us. (There are some unexplained bug reports in https://github.com/doubleunion/arooo/issues/317)

My intent is to make any future application submissions easier to diagnose, as well as to make the "double submission" scenario more applicant-friendly.

### How is this code tested?

Added test cases.

### Are any database migrations required by this change?

No.

### Are there any configuration or environment changes needed?

No.
