### PR TITLE
Add notes about scholarship processing to member setup email reminders

### DIFF
--- a/app/views/new_members_mailer/fourteen_day_reminder.html.haml
+++ b/app/views/new_members_mailer/fourteen_day_reminder.html.haml
@@ -5,13 +5,15 @@
   We are so excited for you to be a member of Double Union that we keep sending you even more emails.
 
 %p
-  Before your membership is a real thing, we need you to fill out a very short form. As soon as possible, log into #{ link_to "the site", EXTERNAL_SITE_URL } ("Log in" is at top right) and confirm your membership #{ link_to "on this page", members_user_setup_url(@user.id) }.
+  Before your membership is a real thing, we need you to set up your dues and and tell us a Google-friendly email address we should use for your access. As soon as possible, log into #{ link_to "the site", EXTERNAL_SITE_URL } ("Log in" is at top right) and confirm your membership #{ link_to "on this page", members_user_setup_url(@user.id) }.
 
 %p
   If you have any questions, email the membership coordinators at #{ mail_to MEMBERSHIP_EMAIL }! If you're no longer interested in being a member, just email us and we'll stop bugging you <3
+  
+%p (If you've already submitted a request for a dues scholarship and filled out your Google-friendly email address, you can ignore this email - it'll resolve itself when your request is processed.)
 
 %p
-  (If we don't hear from you within a month of when you were accepted, we'll assume that you're no longer interested in joining.)
+  If we don't hear from you within a month of when you were accepted, we'll assume that you're no longer interested in joining.
 
 %p
   All the best,

--- a/app/views/new_members_mailer/seven_day_reminder.html.haml
+++ b/app/views/new_members_mailer/seven_day_reminder.html.haml
@@ -5,7 +5,9 @@
   We are so excited for you to be a member of Double Union that we just keep sending you emails.
 
 %p
-  Before your membership is a real thing, we need you to fill out a very short form. As soon as possible, log into #{ link_to "the site", EXTERNAL_SITE_URL } ("Log in" is at top right) and confirm your membership #{ link_to "on this page", members_user_setup_url(@user.id) }.
+  Before your membership is a real thing, we need you to set up your dues and tell us a Google-friendly email address we should use for your access. As soon as possible, log into #{ link_to "the site", EXTERNAL_SITE_URL } ("Log in" is at top right) and confirm your membership #{ link_to "on this page", members_user_setup_url(@user.id) }.
+  
+%p (If you've already submitted a request for a dues scholarship and filled out your Google-friendly email address, you can ignore this email - it'll resolve itself when your request is approved.)
 
 %p
   If you have any questions, email the membership coordinators at #{ mail_to MEMBERSHIP_EMAIL }!

--- a/app/views/new_members_mailer/three_day_reminder.html.haml
+++ b/app/views/new_members_mailer/three_day_reminder.html.haml
@@ -1,11 +1,12 @@
 %p
   Hi #{@user.name}!
 
-%p We are so excited for you to be a member of Double Union. Before things are official, though, we need you to confirm your membership. As soon as possible, log into #{ link_to "the site", EXTERNAL_SITE_URL } ("Log in" is at top right) and confirm your membership #{ link_to "on this page", members_user_setup_url(@user.id) }.
+%p We are so excited for you to be a member of Double Union. Before things are official, though, we need you to set up your dues and tell us a Google-friendly email address we should use for your access. As soon as possible, log into #{ link_to "the site", EXTERNAL_SITE_URL } ("Log in" is at top right) and confirm your membership #{ link_to "on this page", members_user_setup_url(@user.id) }.
+
+%p (If you've already submitted a request for a dues scholarship and filled out your Google-friendly email address, you can ignore this email - it'll resolve itself when your request is approved.)
 
 %p
   If you have any questions, email the membership coordinators at #{ mail_to MEMBERSHIP_EMAIL }!
-
 
 %p
   All the best,

--- a/app/views/new_members_mailer/twenty_one_day_reminder.html.haml
+++ b/app/views/new_members_mailer/twenty_one_day_reminder.html.haml
@@ -4,6 +4,8 @@
 %p
   If you're still excited about Double Union, sometime in the next seven days just fill out this #{ link_to "very short form", members_user_setup_url(@user.id) }. If we don't hear from you (via that form or by emailing the membership coordinators), we're going to cancel your membership in seven days since we'll assume you're not interested.
 
+%p If you've already submitted a request for a dues scholarship and filled out your Google-friendly email address, and you're still waiting for your scholarship request to be processed, please email board@doubleunion.org and copy the membership coordinators to let them know they need to process your scholarship request. Your membership won't be cancelled while you're waiting on hearing about this.
+
 %p
   If you have any questions, email the membership coordinators at #{ mail_to MEMBERSHIP_EMAIL }!
 


### PR DESCRIPTION
### What does this code do, and why?

Currently if a new member applies for a dues scholarship and is waiting to hear back about it, the Arooo system doesn't know that they're waiting on something (they look like they just haven't finished setting up their account), so they keep getting confusing email reminders about setting up their account.

Until we can come up with a better fix, this is a text change to tell people it's ok to ignore the emails if they're waiting on a scholarship application.

This addresses the main issue described at https://github.com/doubleunion/arooo/issues/339

### How is this code tested?

I don't know

### Are any database migrations required by this change?

No

### Screenshots (before/after)

I don't have screenshots - I worked on it locally.

### Are there any configuration or environment changes needed?

No