### PR TITLE
Update "Bookmarks for Members" to help members navigate DU tools

### DIFF
--- a/app/views/members/users/_bookmarks.html.haml
+++ b/app/views/members/users/_bookmarks.html.haml
@@ -3,7 +3,7 @@
   %ul
     %li #{ link_to "Members mailing list", "https://groups.google.com/a/doubleunion.org/forum/#!forum/members", target: "_blank" }
     %li #{ link_to "Members folder in Google Drive", "https://drive.google.com/folderview?id=0B6a_aDP-2fOVV2FQLW5FVTZ2Mjg", target: "_blank" } &mdash; For easy access,  #{ link_to "add a shortcut in your own Google Drive", "https://support.google.com/drive/answer/2375057?hl=en", target: "_blank" }.
-    %li #{ link_to "Members Handbook", "https://docs.google.com/document/d/1yYXAj8rzQMiYt2xFdzm2xEOe0LCHohWNrMWzad-4mtQ/edit", target: "_blank" } &mdash; This will include space access instructions when we have a physical space again.
+    %li #{ link_to "Members Handbook", "https://docs.google.com/document/d/1yYXAj8rzQMiYt2xFdzm2xEOe0LCHohWNrMWzad-4mtQ/edit", target: "_blank" } &mdash; This will include space entry instructions when we have a physical space again.
     %li #{ link_to "Members calendar", "https://www.google.com/calendar/embed?src=br12b81lfe63rggddlg0k92mko@group.calendar.google.com&ctz=America/Los_Angeles", target: "_blank" } &mdash; This is a view-only version of the calendar. To add or edit events, go to #{ link_to "Google Calendar", "https://calendar.google.com/calendar/", target: "_blank" } (it should show up among your calendars).
     %li #{ link_to "Members Slack chat", "https://doubleunion.slack.com/", target: "_blank" }
     %li #{ link_to "DU web application code on GitHub", "https://github.com/doubleunion", target: "_blank" }

--- a/app/views/members/users/_bookmarks.html.haml
+++ b/app/views/members/users/_bookmarks.html.haml
@@ -2,8 +2,8 @@
   %h3 Bookmarks for Members
   %ul
     %li #{ link_to "Members mailing list", "https://groups.google.com/a/doubleunion.org/forum/#!forum/members", target: "_blank" }
-    %li #{ link_to "Members folder in Google Drive", "https://drive.google.com/folderview?id=0B6a_aDP-2fOVV2FQLW5FVTZ2Mjg", target: "_blank" }
-    %li #{ link_to "Members Handbook", "https://docs.google.com/document/d/1yYXAj8rzQMiYt2xFdzm2xEOe0LCHohWNrMWzad-4mtQ/edit", target: "_blank" } &mdash; includes access instructions
-    %li #{ link_to "DU Members calendar in Google calendars", "https://www.google.com/calendar/embed?src=br12b81lfe63rggddlg0k92mko@group.calendar.google.com&ctz=America/Los_Angeles", target: "_blank" }
-    %li #{ link_to "DU Slack chat", "https://doubleunion.slack.com/", target: "_blank" }
-    %li #{ link_to "the DU app on GitHub", "https://github.com/doubleunion/arooo", target: "_blank" }
+    %li #{ link_to "Members folder in Google Drive", "https://drive.google.com/folderview?id=0B6a_aDP-2fOVV2FQLW5FVTZ2Mjg", target: "_blank" } &mdash; For easy access,  #{ link_to "add a shortcut in your own Google Drive", "https://support.google.com/drive/answer/2375057?hl=en", target: "_blank" }.
+    %li #{ link_to "Members Handbook", "https://docs.google.com/document/d/1yYXAj8rzQMiYt2xFdzm2xEOe0LCHohWNrMWzad-4mtQ/edit", target: "_blank" } &mdash; This will include space access instructions when we have a physical space again.
+    %li #{ link_to "Members calendar", "https://www.google.com/calendar/embed?src=br12b81lfe63rggddlg0k92mko@group.calendar.google.com&ctz=America/Los_Angeles", target: "_blank" } &mdash; This is a view-only version of the calendar. To add or edit events, go to #{ link_to "Google Calendar", "https://calendar.google.com/calendar/", target: "_blank" } (it should show up among your calendars).
+    %li #{ link_to "Members Slack chat", "https://doubleunion.slack.com/", target: "_blank" }
+    %li #{ link_to "DU web application code on GitHub", "https://github.com/doubleunion", target: "_blank" }

--- a/app/views/members/users/_bookmarks.html.haml
+++ b/app/views/members/users/_bookmarks.html.haml
@@ -3,12 +3,7 @@
   %ul
     %li #{ link_to "Members mailing list", "https://groups.google.com/a/doubleunion.org/forum/#!forum/members", target: "_blank" }
     %li #{ link_to "Members folder in Google Drive", "https://drive.google.com/folderview?id=0B6a_aDP-2fOVV2FQLW5FVTZ2Mjg", target: "_blank" }
-    %li #{ link_to "Members Handbook", "https://docs.google.com/document/d/1yYXAj8rzQMiYt2xFdzm2xEOe0LCHohWNrMWzad-4mtQ/edit", target: "_blank" }
+    %li #{ link_to "Members Handbook", "https://docs.google.com/document/d/1yYXAj8rzQMiYt2xFdzm2xEOe0LCHohWNrMWzad-4mtQ/edit", target: "_blank" } &mdash; includes access instructions
     %li #{ link_to "DU Members calendar in Google calendars", "https://www.google.com/calendar/embed?src=br12b81lfe63rggddlg0k92mko@group.calendar.google.com&ctz=America/Los_Angeles", target: "_blank" }
     %li #{ link_to "DU Slack chat", "https://doubleunion.slack.com/", target: "_blank" }
     %li #{ link_to "the DU app on GitHub", "https://github.com/doubleunion/arooo", target: "_blank" }
-
-- if current_user.key_member? or current_user.voting_member?
-  %h3 Bookmarks for Key Members
-  %ul
-    %li #{ link_to "Instructions for accessing the space", "https://docs.google.com/document/d/1yYXAj8rzQMiYt2xFdzm2xEOe0LCHohWNrMWzad-4mtQ/edit#heading=h.bzddvad2czon", target: "_blank" }

--- a/app/views/members/users/_bookmarks.html.haml
+++ b/app/views/members/users/_bookmarks.html.haml
@@ -1,12 +1,12 @@
 - if current_user.general_member?
   %h3 Bookmarks for Members
   %ul
-    %li= link_to "Members mailing list", "https://groups.google.com/a/doubleunion.org/forum/#!forum/members", target: "_blank"
-    %li= link_to "Members folder in Google Drive", "https://drive.google.com/folderview?id=0B6a_aDP-2fOVV2FQLW5FVTZ2Mjg", target: "_blank"
-    %li= link_to "Members Handbook", "https://docs.google.com/document/d/1yYXAj8rzQMiYt2xFdzm2xEOe0LCHohWNrMWzad-4mtQ/edit", target: "_blank"
-    %li= link_to "DU Members calendar in Google calendars", "https://www.google.com/calendar/embed?src=br12b81lfe63rggddlg0k92mko@group.calendar.google.com&ctz=America/Los_Angeles", target: "_blank"
-    %li= link_to "DU Slack chat", "https://doubleunion.slack.com/", target: "_blank"
-    %li= link_to "the DU app on GitHub", "https://github.com/doubleunion/arooo", target: "_blank"
+    %li #{ link_to "Members mailing list", "https://groups.google.com/a/doubleunion.org/forum/#!forum/members", target: "_blank" }
+    %li #{ link_to "Members folder in Google Drive", "https://drive.google.com/folderview?id=0B6a_aDP-2fOVV2FQLW5FVTZ2Mjg", target: "_blank" }
+    %li #{ link_to "Members Handbook", "https://docs.google.com/document/d/1yYXAj8rzQMiYt2xFdzm2xEOe0LCHohWNrMWzad-4mtQ/edit", target: "_blank" }
+    %li #{ link_to "DU Members calendar in Google calendars", "https://www.google.com/calendar/embed?src=br12b81lfe63rggddlg0k92mko@group.calendar.google.com&ctz=America/Los_Angeles", target: "_blank" }
+    %li #{ link_to "DU Slack chat", "https://doubleunion.slack.com/", target: "_blank" }
+    %li #{ link_to "the DU app on GitHub", "https://github.com/doubleunion/arooo", target: "_blank" }
 
 - if current_user.key_member? or current_user.voting_member?
   %h3 Bookmarks for Key Members


### PR DESCRIPTION
### What does this code do, and why?

This updates the "Bookmarks for Members" list on the DU internal app homepage to add context that should resolve a couple of common user confusions: https://github.com/doubleunion/arooo/issues/222 + https://github.com/doubleunion/arooo/issues/215. I also removed the "Bookmarks for Key Members" section because it was just another link to the Member Handbook.

![Screen Shot 2020-12-21 at 2 20 29 PM](https://user-images.githubusercontent.com/391313/102827585-ae666180-4397-11eb-9094-f087f967b13c.png)

### How is this code tested?

I imagine it doesn't need or have any specific tests, because it's just a set of text changes.

### Are any database migrations required by this change?

No

### Screenshots (before/after)

This is the "before" view:

![Screen Shot 2020-12-21 at 2 23 32 PM](https://user-images.githubusercontent.com/391313/102827803-1b79f700-4398-11eb-8087-a526b80765c3.png)

### Are there any configuration or environment changes needed?

No