### PR TITLE
Add Instagram and Facebook links to header

### DIFF
--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -11,6 +11,8 @@
       %ul.nav.navbar-nav
         %li= external_link_to 'Blog', TUMBLR_URL
         %li= external_link_to 'Twitter', TWITTER_URL
+        %li= external_link_to 'Instagram', INSTAGRAM_URL
+        %li= external_link_to 'Facebook', FACEBOOK_URL
 
       - if logged_in?
         %ul.nav.navbar-nav.pull-right

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -10,7 +10,10 @@ KEYS_EMAIL = "keys@doubleunion.org"
 SCHOLARSHIP_EMAIL = "scholarship@doubleunion.org"
 
 TUMBLR_BASE = "doubleunion.tumblr.com"
-TUMBLR_URL = "http://#{TUMBLR_BASE}"
+TUMBLR_URL = "https://#{TUMBLR_BASE}"
+
+FACEBOOK_URL = "https://www.facebook.com/doubleunion"
+INSTAGRAM_URL = "https://www.instagram.com/doubleunionsf/"
 
 MAILING_LIST_GENERAL = "https://groups.google.com/a/doubleunion.org/forum/#!forum/public"
 GOOGLE_ANALYTICS_ID = "UA-47411942-1"


### PR DESCRIPTION
### What does this code do, and why?

This adds Instagram and Facebook links to the header bar, to make them easier to access for members. They're probably still not totally visible and easy to find, but at least it's better! This closes https://github.com/doubleunion/arooo/issues/417.

### How is this code tested?

I don't think there are tests for this.

### Are any database migrations required by this change?

No.

### Screenshots (before/after)

Before:

![94601641-9f648d00-0248-11eb-9809-72edf6efd3db](https://user-images.githubusercontent.com/391313/102943391-be9c4080-446c-11eb-875a-2cbc23a9a2d7.png)

After:

![Screen Shot 2020-12-22 at 3 45 51 PM](https://user-images.githubusercontent.com/391313/102943397-c5c34e80-446c-11eb-987c-cdd72b711a99.png)

### Are there any configuration or environment changes needed?

I changed the constants file to reflect the structure that was already in place.