### PR TITLE
Help members understand how to edit their profile information

### DIFF
--- a/app/views/members/users/edit.html.haml
+++ b/app/views/members/users/edit.html.haml
@@ -17,7 +17,7 @@
     %fieldset
       = fields.check_box :show_name_on_site
       = fields.label :show_name_on_site,
-        "Show name/website/gravatar on #{link_to 'public site', EXTERNAL_SITE_URL + "/membership#current-members"}?".html_safe,
+        "Show name, website, and #{link_to 'Gravatar', "https://en.gravatar.com/support/what-is-gravatar/" } on #{link_to 'DU public website', EXTERNAL_SITE_URL + "/membership#current-members"}?".html_safe,
         class: 'checkbox-label'
 
     %fieldset

--- a/app/views/members/users/edit.html.haml
+++ b/app/views/members/users/edit.html.haml
@@ -17,7 +17,7 @@
     %fieldset
       = fields.check_box :show_name_on_site
       = fields.label :show_name_on_site,
-        "Show name, website, and #{link_to 'Gravatar', "https://en.gravatar.com/support/what-is-gravatar/" } on #{link_to 'DU public website', EXTERNAL_SITE_URL + "/membership#current-members"}?".html_safe,
+        "Show name, website, and #{link_to 'Gravatar', "https://en.gravatar.com/support/what-is-gravatar/" } (if you've set up a Gravatar) on #{link_to 'DU public website', EXTERNAL_SITE_URL + "/membership#current-members"}?".html_safe,
         class: 'checkbox-label'
 
     %fieldset
@@ -33,8 +33,10 @@
       = fields.text_field :pronouns
 
     %fieldset
-      %legend= user_f.label :email, 'Email'
+      %legend= user_f.label :email, 'Email displayed on member profile'
       = user_f.text_field :email
+    
+    %p If you need to also change your "Google-friendly" email address that DU uses for your Google Drive, Google Calendar, and Google Groups access (for example, if you've lost access to that Google account or are switching to using a new Google account), please email the Membership Coordinators (#{ mail_to MEMBERSHIP_EMAIL }). They will need to manually update your account in those systems.
 
     %fieldset
       %legend= fields.label :twitter, 'Twitter username'

--- a/app/views/members/users/edit.html.haml
+++ b/app/views/members/users/edit.html.haml
@@ -17,7 +17,7 @@
     %fieldset
       = fields.check_box :show_name_on_site
       = fields.label :show_name_on_site,
-        "Show name/website/gravatar on #{link_to 'public site', EXTERNAL_SITE_URL + "/membership"}?".html_safe,
+        "Show name/website/gravatar on #{link_to 'public site', EXTERNAL_SITE_URL + "/membership#current-members"}?".html_safe,
         class: 'checkbox-label'
 
     %fieldset
@@ -25,7 +25,7 @@
       = user_f.text_field :name
 
     %fieldset
-      %legend= user_f.label :pronounceable_name
+      %legend= user_f.label :pronounceable_name, 'How to pronounce your name (used by automated voice for door entry system)'
       = user_f.text_field :pronounceable_name
 
     %fieldset
@@ -41,19 +41,19 @@
       = fields.text_field :twitter
 
     %fieldset
-      %legend= fields.label :facebook, 'Facebook url'
+      %legend= fields.label :facebook, 'Facebook URL'
       = fields.text_field :facebook
 
     %fieldset
-      %legend= fields.label :website, 'Website url'
+      %legend= fields.label :website, 'Website URL'
       = fields.text_field :website
 
     %fieldset
-      %legend= fields.label :linkedin, 'LinkedIn url'
+      %legend= fields.label :linkedin, 'LinkedIn URL'
       = fields.text_field :linkedin
 
     %fieldset
-      %legend= fields.label :blog, 'Blog url'
+      %legend= fields.label :blog, 'Blog URL'
       = fields.text_field :blog
 
     %fieldset

--- a/app/views/members/users/edit.html.haml
+++ b/app/views/members/users/edit.html.haml
@@ -35,8 +35,10 @@
     %fieldset
       %legend= user_f.label :email, 'Email displayed on member profile'
       = user_f.text_field :email
-    
-    %p If you need to also change your "Google-friendly" email address that DU uses for your Google Drive, Google Calendar, and Google Groups access (for example, if you've lost access to that Google account or are switching to using a new Google account), please email the Membership Coordinators (#{ mail_to MEMBERSHIP_EMAIL }). They will need to manually update your account in those systems.
+
+    %strong Google-friendly email
+    %div #{@user.email_for_google}
+    %p If you need to also change the "Google-friendly" email address that DU uses for your Google Drive, Google Calendar, and Google Groups access (for example, if you've lost access to that Google account or are switching to using a new Google account), please email the Membership Coordinators (#{ mail_to MEMBERSHIP_EMAIL }). They will need to manually update your account in those systems.
 
     %fieldset
       %legend= fields.label :twitter, 'Twitter username'

--- a/app/views/members/users/index.html.haml
+++ b/app/views/members/users/index.html.haml
@@ -13,13 +13,13 @@
     %p Your door code is: #{current_user.door_code.code} #{current_user.door_code.enabled? ? "(enabled)" : "(disabled)"}
   - else
     %p
-      You don't seem to have a door code set. Please contact
-      =mail_to "membership@doubleunion.com"
+      You don't seem to have a door code set. If you need one, contact
+      =mail_to MEMBERSHIP_EMAIL
       for help.
 
 - if @all_admins.any?
   %h3 Admins
-  %p This internal DU app is administered by DU Membership Coordinators (membership@doubleunion.org) and Board Members (board@doubleunion.org), and it many also have Web App committee members supporting it. Members with admin access: 
+  %p This internal DU app is administered by Membership Coordinators (#{ mail_to MEMBERSHIP_EMAIL }) and Board Members (#{ mail_to BOARD_EMAIL }), and it may also have Web App committee members supporting it. Members with admin access: 
   = render partial: 'list', locals: { users: @all_admins }
 
 - if @all_members.any?

--- a/spec/features/members_home_spec.rb
+++ b/spec/features/members_home_spec.rb
@@ -11,7 +11,7 @@ describe "Members home" do
     it "if they have no door code, tells them to email membership@" do
       visit members_root_path
       expect(page).to have_content "don't seem to have a door code"
-      expect(page).to have_content "membership@doubleunion.com"
+      expect(page).to have_content "membership@doubleunion.org"
     end
 
     it "if they have a door code, it is shown" do


### PR DESCRIPTION
### What does this code do, and why?

These changes should help members understand:

* What a Gravatar is (if they've never heard of one)
* How to fill out the pronounceable-name field
* How and why to update their Google-friendly email address
* That it's ok if they don't have a door code if they don't need one

I also corrected the membership coordinator email address from .com to .org by using the constant for it.

This closes https://github.com/doubleunion/arooo/issues/530 and https://github.com/doubleunion/arooo/issues/531.

### How is this code tested?

I attempted to update the relevant test as well.

### Are any database migrations required by this change?

No

### Screenshots (before/after)

After, edit profile page:
![Screen Shot 2020-12-23 at 2 07 53 PM](https://user-images.githubusercontent.com/391313/103040427-41ce9c80-4528-11eb-96c2-1ee89e02642b.png)

After, member homepage:
![Screen Shot 2020-12-23 at 2 10 31 PM](https://user-images.githubusercontent.com/391313/103040544-9ffb7f80-4528-11eb-93d1-fc4f324fed95.png)

### Are there any configuration or environment changes needed?

No