### PR TITLE
Rename "Manage Dues" to "Manage Membership"

### DIFF
--- a/app/views/dues_mailer/failed.html.haml
+++ b/app/views/dues_mailer/failed.html.haml
@@ -2,7 +2,7 @@
   Hey there!
 
 %p
-  Your last dues payment failed for some reason. If your credit card has expired or you've gotten a new card, please #{ link_to "visit the Double Union app", root_url } to update your card information (click "Manage Dues" in the pink member navbar). Filling out the form again will update your dues, not create a new set of charges.
+  Your last dues payment failed for some reason. If your credit card has expired or you've gotten a new card, please #{ link_to "visit the Double Union app", root_url } to update your card information (click "Manage Membership" in the pink member navbar). Filling out the form again will update your dues, not create a new set of charges.
 
 %p
   If you have any questions or concerns, email the membership coordinators at #{ mail_to MEMBERSHIP_EMAIL }.

--- a/app/views/layouts/_member_nav.html.haml
+++ b/app/views/layouts/_member_nav.html.haml
@@ -10,8 +10,8 @@
       %ul.nav.navbar-nav
         %li.no-padding= link_to 'Members Home', members_users_path
         %li= link_to 'Applications', members_applications_path
-        %li= link_to 'Edit profile', edit_members_user_path(current_user)
-        %li= link_to 'Manage Dues', members_user_dues_path(current_user)
+        %li= link_to 'Edit Profile', edit_members_user_path(current_user)
+        %li= link_to 'Manage Membership', members_user_dues_path(current_user)
         - if current_user.is_admin?
           %li.dropdown
             %a{ href: '#', class: 'dropdown-toggle', :'data-toggle' => 'dropdown' }

--- a/app/views/members/dues/show.html.haml
+++ b/app/views/members/dues/show.html.haml
@@ -3,11 +3,18 @@
 
 %h2 Manage Membership
 
+%ul
+  %li #{ link_to "Update Membership Dues", "#update-membership-dues" }
+  %li #{ link_to "Apply for a Scholarship", "#apply-for-a-scholarship" }
+  %li #{ link_to "Cancel Your Membership", "#cancel-your-membership" }
+
+%h3#update-membership-dues Update Membership Dues
+
 %p Membership dues payments are handled via Stripe, which will charge your credit or debit card on the same date each month.
 
 %p If you need to change your dues payment, just fill in the form again and it will be updated. (If you switch your dues to a lower level, our dues system automatically pro-rates your next payments, so you may get charged a lower partial amount [or nothing] on your next scheduled dues payment date. This is ok!)
 
-%h3 Current Dues Status
+%h4#your-dues-status Your Current Dues Status
 
 - if @subscription
   %p
@@ -27,10 +34,10 @@
 = render 'form', action: "Update"
 
 
-%h3 Apply for a Scholarship
+%h3#apply-for-a-scholarship Apply for a Scholarship
 
 = render "scholarship_request"
 
 .cancel-membership
-  %h3 Cancel your Membership
+  %h3#cancel-your-membership Cancel Your Membership
   %p If you'd like to cancel your Double Union membership, click #{link_to "here", members_user_cancel_path, method: :delete, id: "cancel-btn", data: { confirm: "Are you sure? Clicking yes will cancel your payments, and inform the membership coordinator to remove you from all mailing lists." } }. If you have other questions about dues and membership, please email #{ mail_to MEMBERSHIP_EMAIL } to reach out to the membership coordinators.

--- a/app/views/members/dues/show.html.haml
+++ b/app/views/members/dues/show.html.haml
@@ -1,7 +1,7 @@
 = content_for :js do
   = javascript_include_tag :dues
 
-%h2 Manage Your Double Union Dues
+%h2 Manage Membership
 
 %p Membership dues payments are handled via Stripe, which will charge your credit or debit card on the same date each month.
 

--- a/app/views/members/users/setup.html.haml
+++ b/app/views/members/users/setup.html.haml
@@ -31,7 +31,7 @@
 %p
   We also gladly welcome and support members who can't afford to pay membership dues!
   Any member can request a scholarship due to financial need at any time.
-  To apply for a scholarship, go to the #{ link_to "manage dues page", members_user_dues_path(@user) } and fill out the form.
+  To apply for a scholarship, go to #{ link_to "Manage Membership", members_user_dues_path(@user) } and fill out the form.
 
 = render 'members/dues/form', action: "Set Up"
 

--- a/spec/controllers/members/dues_controller_spec.rb
+++ b/spec/controllers/members/dues_controller_spec.rb
@@ -59,7 +59,7 @@ describe Members::DuesController do
     subject(:cancel_dues) { delete :cancel, params: params }
 
     context "when the user does not have a Stripe ID" do
-      it "sets the flash and redirects to the manage dues page" do
+      it "sets the flash and redirects to the Manage Membership page" do
         expect(subject).to redirect_to members_user_dues_path(user)
         expect(flash[:notice]).to include "You don't have an active membership dues subscription"
       end
@@ -178,7 +178,7 @@ describe Members::DuesController do
           expect(subscription.plan.id).to eq("test_plan")
         end
 
-        it "redirects to the manage dues page" do
+        it "redirects to the Manage Membership page" do
           expect(subject).to redirect_to members_user_dues_path(user)
         end
       end

--- a/spec/features/cancel_membership_spec.rb
+++ b/spec/features/cancel_membership_spec.rb
@@ -56,8 +56,8 @@ describe "canceling dues", js: true do
       .with(member.stripe_customer_id)
       .and_return(customer)
 
-    click_on "Manage Dues"
-    expect(page).to have_content "Manage Your Double Union Dues"
+    click_on "Manage Membership"
+    expect(page).to have_content "Manage Membership"
     message = accept_alert {
       click_link "here"
     }


### PR DESCRIPTION
### What does this code do, and why?

This renames the "Manage Dues" page to "Manage Membership" because the page allows you to do multiple things related to managing your membership. It also adds a table of contents to the top of the page, because people frequently miss that there's a "cancel your membership" option at the bottom of the page.

This closes https://github.com/doubleunion/arooo/issues/514

### How is this code tested?

I attempted to update the tests to match the change.

### Are any database migrations required by this change?

No

### Screenshots (before/after)

After:

![Screen Shot 2020-12-23 at 4 02 48 PM](https://user-images.githubusercontent.com/391313/103045175-50bd4b00-4538-11eb-84e4-d58bf961c81b.png)

### Are there any configuration or environment changes needed?

No