### PR TITLE
Make orientation configurable + remove address from welcome email

### DIFF
--- a/app/views/applications_mailer/approved.html.haml
+++ b/app/views/applications_mailer/approved.html.haml
@@ -7,7 +7,7 @@
 
       %p In order to confirm your membership, log into #{ link_to "the site", EXTERNAL_SITE_URL } ("Log in" is at top right) and complete the setup #{ link_to "on this page", members_user_setup_url(@user.id) }. This is where you'll give us your Google-friendly email address for our calendar and mailing list, and set up dues (or apply for a scholarship). (After you’ve done this, a membership coordinator will subscribe you to the mailing list and invite you to Slack. Feel free to start a thread introducing yourself and jump into conversations right away!)
 
-      %p Please also sign up for a #{ link_to "New Member Orientation", ORIENTATION_SIGNUP_URL } so we can get you set up with your own access to the space!
+      %p Please also sign up for a #{ link_to "New Member Orientation", Configurable[:orientation_signup] } so we can get you set up with your own access to the space!
 
       %p If you want to be listed publicly as a member (at the bottom of #{ link_to "this page", MEMBERSHIP_URL }), #{ link_to "log in", login_url } to the app and go to "Edit profile" in the right dropdown menu. There's a checkbox there marked "Show name/website/gravatar on public site?"
 
@@ -18,19 +18,6 @@
         %li Give you access to the Double Union Google Drive folder and Google Calendar
         %li Give you access to the Double Union Slack chat
         %li Tell you when the new member orientation meetings will be
-
-      %p
-        In case you don't have it, here's the DU address:
-        %br/
-        Double Union
-        %br/
-        1250 Missouri Street, Suite 111
-        %br/
-        San Francisco, CA 94107
-
-      %p When you're a new member, you can visit when other people are already in the space (such as during events announced on the mailing list). When you get to the building: the ground floor has a glass door with a keypad to the right. You can use the keypad to dial the pound sign (#) and then our suite number (111) to call the phone in the space, and a person in the space can let you in by answering the phone. Then go inside and take the elevator up to the first floor. The space is down the hall to your left!
-
-      %p When you attend a new member orientation, you’ll have the option to become a key member. As a key member you’d be able to enter the space even when other members are not already in the space. There are a number of responsibilities you would accept as a key member, which will be explained in the new member orientation.
 
       %p If you have any questions, email the membership coordinator at #{ mail_to MEMBERSHIP_EMAIL }.
 

--- a/config/configurable.yml
+++ b/config/configurable.yml
@@ -10,6 +10,9 @@ voting_member_policy_doc:
 
 onboarding_offboarding_checklist:
   type: text
+  
+orientation_signup:
+  type: text
 
 # This file controls what config variables you want to be able to allow your users
 # to set, as well as those you'll be able to access from within the application.

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -23,7 +23,6 @@ EXTERNAL_SITE_URL = "https://www.doubleunion.org"
 BASE_ASSUMPTIONS_URL = EXTERNAL_SITE_URL + "/base_assumptions"
 POLICIES_URL = EXTERNAL_SITE_URL + "/policies"
 MEMBERSHIP_URL = EXTERNAL_SITE_URL + "/membership"
-ORIENTATION_SIGNUP_URL = "https://www.eventbrite.com/e/new-member-orientation-summer-2019-tickets-63172051306"
 
 KEY_PICKUP_DOC = "https://docs.google.com/document/d/1RYzqGjmA3lLhv9eQzHBg82NVNjik4w_kxi8sKP5ivaY/edit?usp=sharing"
 LOCK_UP_DOC = "https://docs.google.com/document/d/1rFoyl5FJjDdr0LqiVacQPuKyj_rsmPpOnAGc77cWTAQ/edit?usp=sharing"

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -18,6 +18,11 @@ describe AdminController do
       describe "with good params" do
         let(:application_params) { {application: {id: an_application.id}} }
 
+        before do
+          # Shortcircuit actually mailing the approval email
+          allow(ApplicationsMailer).to receive_message_chain(:approved, :deliver_now)
+        end
+
         it "should approve the relevant application" do
           login_as(:voting_member, is_admin: true)
           expect {

--- a/spec/mailers/applications_mailer_spec.rb
+++ b/spec/mailers/applications_mailer_spec.rb
@@ -40,6 +40,7 @@ describe ApplicationsMailer do
 
   describe "when someone is accepted" do
     before do
+      Configurable[:orientation_signup] = "http://fake.orientation"
       application.approve
     end
 
@@ -47,6 +48,10 @@ describe ApplicationsMailer do
 
     it "is sent to the applicant" do
       expect(mail.to).to include(application.user.email)
+    end
+
+    it "includes a link to orientiation signup" do
+      expect(mail.body).to include("http://fake.orientation")
     end
   end
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -24,6 +24,11 @@ describe Application do
 
     subject { application.approve }
 
+    before do
+      # We need to have an orientation_signup configured for emails to work
+      Configurable[:orientation_signup] = "http://fake.orientation"
+    end
+
     it "sends an email to the applicant" do
       expect { subject }.to change(ActionMailer::Base.deliveries, :count).by(1)
     end


### PR DESCRIPTION
### What does this code do, and why?

Make the orientation link configurable, so that people don't have to edit the constants when there's a new orientation signup link. Also remove DU's old address from the welcome email (this will need to be updated when DU has a physical space again - noted at https://github.com/doubleunion/arooo/issues/538).

This closes https://github.com/doubleunion/arooo/issues/336. Syd and I worked on this together.

### How is this code tested?

Not sure

### Are any database migrations required by this change?

No

### Screenshots (before/after)
![Screen Shot 2020-12-27 at 3 57 10 PM](https://user-images.githubusercontent.com/391313/103181982-2af7b500-485c-11eb-8f71-93a6429bab23.png)

### Are there any configuration or environment changes needed?

I don't think so.