### PR TITLE
Tell the membership coordinator that the orientation link must be configured

### DIFF
--- a/app/views/admin/applications.html.haml
+++ b/app/views/admin/applications.html.haml
@@ -7,7 +7,9 @@
       %li Fewer than 2 no votes
       %li 1+ sponsor(s)
 
-    %p Clicking "Approve" makes the person a member, sends them an email notifying them, and moves them into the New Member page, where the new member coordinators help get them set up.
+    %p Clicking "Approve" makes the person a member, sends them an email notifying them*, and moves them into the New Member page, where the membership coordinators help get them set up.
+    
+    %p <em>*You need to #{ link_to "configure an orientation signup link", admin_configurable_path }! The automated email gives the new member that link to sign up for an orientation session. If that link is blank, the email won't get sent.</em>
 
     %p Clicking "Reject" marks the person's application as rejected, but doesn't do anything else. Rejection emails are still a manual process from the membership@ email address.
 


### PR DESCRIPTION
### What does this code do, and why?

This is a followup on https://github.com/doubleunion/arooo/pull/539. It adds a note telling the person accepting applications to configure the orientation signup link.

### How is this code tested?

It's not, but it's just a text change, so that should be ok.

### Are any database migrations required by this change?

No

### Screenshots (before/after)

After:

![Screen Shot 2021-01-02 at 4 17 34 PM](https://user-images.githubusercontent.com/391313/103469159-07c67d00-4d16-11eb-8fb3-050494b28fb9.png)

### Are there any configuration or environment changes needed?

No