### PR TITLE
Remove old constants, including keys email that we don't use

### DIFF
--- a/app/controllers/members/key_members_controller.rb
+++ b/app/controllers/members/key_members_controller.rb
@@ -10,7 +10,7 @@ class Members::KeyMembersController < Members::MembersController
       return render :edit
     elsif @new_key_member.member? && @new_key_member.make_key_member!
       send_keymember_email
-      flash[:message] = "Yay, you're now a key member! You've just received an email with instructions for getting set up. Questions? Email #{KEYS_EMAIL}.".html_safe
+      flash[:message] = "Yay, you're now a key member! You've just received an email with instructions for getting set up. Questions? Email #{MEMBERSHIP_EMAIL}.".html_safe
     else
       flash[:error] = "Only members can become key members. If you'd like to change your membership status, email #{MEMBERSHIP_EMAIL}".html_safe
     end

--- a/app/mailers/member_status_mailer.rb
+++ b/app/mailers/member_status_mailer.rb
@@ -5,7 +5,7 @@ class MemberStatusMailer < ActionMailer::Base
     @user = user
 
     mail(
-      to: [MEMBERSHIP_EMAIL, KEYS_EMAIL],
+      to: [MEMBERSHIP_EMAIL],
       cc: [user.email],
       subject: "#{user.name} is now a key member!"
     )

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,12 +1,9 @@
 TWITTER_USERNAME = "doubleunionsf"
 TWITTER_URL = "https://twitter.com/#{TWITTER_USERNAME}"
 
-PRESS_EMAIL = "press@doubleunion.org"
-PAYPAL_EMAIL = "paypal@doubleunion.org"
 JOIN_EMAIL = "join@doubleunion.org"
 MEMBERSHIP_EMAIL = "membership@doubleunion.org"
 BOARD_EMAIL = "board@doubleunion.org"
-KEYS_EMAIL = "keys@doubleunion.org"
 SCHOLARSHIP_EMAIL = "scholarship@doubleunion.org"
 
 TUMBLR_BASE = "doubleunion.tumblr.com"
@@ -24,9 +21,7 @@ BASE_ASSUMPTIONS_URL = EXTERNAL_SITE_URL + "/base_assumptions"
 POLICIES_URL = EXTERNAL_SITE_URL + "/policies"
 MEMBERSHIP_URL = EXTERNAL_SITE_URL + "/membership"
 
-KEY_PICKUP_DOC = "https://docs.google.com/document/d/1RYzqGjmA3lLhv9eQzHBg82NVNjik4w_kxi8sKP5ivaY/edit?usp=sharing"
-LOCK_UP_DOC = "https://docs.google.com/document/d/1rFoyl5FJjDdr0LqiVacQPuKyj_rsmPpOnAGc77cWTAQ/edit?usp=sharing"
 VOTING_CRITERIA_DOC = "https://docs.google.com/document/d/12R7utXAiyCK55XEP8cPscUqu2CXAj-hL5jXE-MaJdgE/edit#heading=h.w83btzy2bttc"
 COMMENTING_DOC = "https://docs.google.com/document/d/12R7utXAiyCK55XEP8cPscUqu2CXAj-hL5jXE-MaJdgE/edit#heading=h.ti79qe36hzgp"
 VOTING_PROCESS_DOC = "https://docs.google.com/document/d/12R7utXAiyCK55XEP8cPscUqu2CXAj-hL5jXE-MaJdgE/edit#heading=h.y6eimvxrwzvf"
-PRONOUNS_GUIDE_URL = "http://www.brynmawr.edu/pensby/documents/AskingforNameandPronouns.pdf"
+PRONOUNS_GUIDE_URL = "https://www.brynmawr.edu/sites/default/files/asking-for-name-and-pronouns.pdf"

--- a/spec/mailers/member_status_mailer_spec.rb
+++ b/spec/mailers/member_status_mailer_spec.rb
@@ -10,7 +10,6 @@ describe MemberStatusMailer do
       it "is sent to the correct addresses" do
         expect(mail.cc).to include member.email
         expect(mail.to).to include MEMBERSHIP_EMAIL
-        expect(mail.to).to include KEYS_EMAIL
       end
 
       it "includes their name" do


### PR DESCRIPTION
### What does this code do, and why?

At the original DU space, we had a role that managed actual physical keys (chatelaine / key wrangler), with their own email address. We don't have a separate role for that anymore, so the key email address is redundant. I removed it from all the places it still existed in the code.

I also removed a few other constants that aren't used in the code anywhere.

### How is this code tested?

Not sure

### Are any database migrations required by this change?

No

### Screenshots (before/after)

None

### Are there any configuration or environment changes needed?

This updates the constants file.