### PR TITLE
Update nokogiri version according to advisory CVE-2020-26247

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem "bigdecimal", "1.4.4" # specify this directly to get around the error NoMeth
 gem "twilio-ruby"
 gem "redis" # Used to store recently-authorized doorbell member
 
+# Avoid low-severity security issue: https://github.com/advisories/GHSA-vr8q-g5c7-m54m
+gem "nokogiri", ">= 1.11.0.rc4"
+
 group :development do
   gem "annotate" # Show db schema as comments in models
   gem "better_errors" # Provides a better error page for Rails and other Rack apps

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,14 +200,15 @@ GEM
     method_source (1.0.0)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.2)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.4)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.0.rc4)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
@@ -241,6 +242,7 @@ GEM
     public_suffix (4.0.5)
     puma (4.3.6)
       nio4r (~> 2.0)
+    racc (1.5.2)
     rack (2.2.3)
     rack-canonical-host (0.2.3)
       addressable (> 0, < 3)
@@ -430,6 +432,7 @@ DEPENDENCIES
   jquery-rails (>= 4.3.5)
   kaminari (>= 1.2.1)
   launchy
+  nokogiri (>= 1.11.0.rc4)
   omniauth
   omniauth-github
   omniauth-google-oauth2


### PR DESCRIPTION
Resolves open dependabot alert due to advisory https://github.com/advisories/GHSA-vr8q-g5c7-m54m
