### PR TITLE
Show logged-in applicants link to edit their application on the homepage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,7 +294,7 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.0)
     rake (13.0.1)
-    redcarpet (3.4.0)
+    redcarpet (3.5.1)
     redis (4.2.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,9 @@ class SessionsController < ApplicationController
 
   def login
     redirect_to members_root_path if current_user.try(:general_member?)
+    if current_user && current_user.applicant?
+      redirect_to(edit_application_path(current_user.application))
+    end
   end
 
   def github

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < ApplicationController
   def login
     redirect_to members_root_path if current_user.try(:general_member?)
     if current_user && current_user.applicant?
-      redirect_to(edit_application_path(current_user.application))
+      #redirect_to(edit_application_path(current_user.application))
     end
   end
 

--- a/app/views/applications/show.html.haml
+++ b/app/views/applications/show.html.haml
@@ -1,4 +1,7 @@
-%h2 View application
+- if logged_in_as?(@user)
+  %h2 Your application
+- else
+  %h2 View application
 
 - if logged_in_as?(@user)
   %p= link_to 'Edit application', edit_application_path(@user.application)

--- a/app/views/sessions/login.html.haml
+++ b/app/views/sessions/login.html.haml
@@ -1,5 +1,5 @@
 - if current_user.try(:applicant?)
-  %h2 Welcome, applicant!
+  %h2 Welcome!
   - if Configurable[:accepting_applications]
     %p= link_to 'Edit your application', edit_application_path(current_user.application)
   - else

--- a/app/views/sessions/login.html.haml
+++ b/app/views/sessions/login.html.haml
@@ -1,11 +1,21 @@
-- if Configurable[:accepting_applications]
-  %h2 Members and Applicants Sign In
+- if current_user.try(:applicant?)
+  %h2 Welcome, applicant!
+  - if Configurable[:accepting_applications]
+    %p= link_to 'Edit your application', edit_application_path(current_user.application)
+  - else
+    %p Double Union isn't currently accepting applications. Join the general interest mailing list linked from
+    =link_to "doubleunion.org/membership", "https://doubleunion.org/membership"
+    to be notified when applications open.
+
 - else
-  %h2 Members Sign In
+  - if Configurable[:accepting_applications]
+    %h2 Members and Applicants Sign In
+  - else
+    %h2 Members Sign In
 
-%p.ib= link_to 'Sign in with GitHub', github_login_path, class: 'btn btn-primary btn-lg mr-20'
-%p.ib= link_to 'Sign in with Google', google_login_path, class: 'btn btn-primary btn-lg'
+  %p.ib= link_to 'Sign in with GitHub', github_login_path, class: 'btn btn-primary btn-lg mr-20'
+  %p.ib= link_to 'Sign in with Google', google_login_path, class: 'btn btn-primary btn-lg'
 
-- if Configurable[:accepting_applications]
-  %p To start an application, first authenticate with Google or GitHub. If you have any questions, email us at #{ mail_to JOIN_EMAIL }.
+  - if Configurable[:accepting_applications]
+    %p To start an application, first authenticate with Google or GitHub. If you have any questions, email us at #{ mail_to JOIN_EMAIL }.
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -18,13 +18,6 @@ describe SessionsController do
       get(:login)
       expect(response).to redirect_to members_root_path
     end
-
-    it "redirects applicant to editing application" do
-      applicant = create(:user, state: :applicant)
-      login_as(applicant)
-      get(:login)
-      expect(response).to redirect_to edit_application_path(applicant.application)
-    end
   end
 
   describe "GET github" do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -12,6 +12,19 @@ describe SessionsController do
     it "renders the page" do
       expect(get(:login)).to render_template :login
     end
+
+    it "redirects member to members home" do
+      login_as(:key_member)
+      get(:login)
+      expect(response).to redirect_to members_root_path
+    end
+
+    it "redirects applicant to editing application" do
+      applicant = create(:user, state: :applicant)
+      login_as(applicant)
+      get(:login)
+      expect(response).to redirect_to edit_application_path(applicant.application)
+    end
   end
 
   describe "GET github" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/doubleunion/arooo/issues/529

### What does this code do, and why?

This PR resolves https://github.com/doubleunion/arooo/issues/529 and contains two changes:
* A logged-in applicant is shown one of two things on the '/' page:
  * if applications are open, a link to edit their application
  * if applications are closed, a notice to that effect, and a link to the website page that links to the announcement mailing list
* When you are viewing (not editing) your own application, changes the header to say "Your application" (instead of "View application").

(Initially I made the homepage redirect an applicant automatically to edit their application, but this turns out to be a Bad Idea in the case when applications are closed, because when applications are closed the "edit your application" page redirects you back to the homepage, which would then create an infinite redirect loop if it sent you back to editing your application.)

### How is this code tested?

Specs and manual testing.

### Are any database migrations required by this change?

No.

### Are there any configuration or environment changes needed?

No.

### Screenshots please :)

**Logged in applicant, applications open**
![Screen Shot 2021-01-17 at 4 09 58 PM](https://user-images.githubusercontent.com/6729309/104860409-3df02900-58e0-11eb-8ee1-c4dff157cb87.png)

**Logged in applicant, applications closed**
![Screen Shot 2021-01-17 at 4 12 29 PM](https://user-images.githubusercontent.com/6729309/104860413-434d7380-58e0-11eb-9a83-4a1431d31c93.png)

**Applicant looking at their own application**
![Screen Shot 2021-01-17 at 3 41 16 PM](https://user-images.githubusercontent.com/6729309/104859772-683fe780-58dc-11eb-80cc-9d87581d1e11.png)
