### PR TITLE
Display applicant emails in two separate lists: with sponsors and no sponsors

### DIFF
--- a/app/controllers/members/applications_controller.rb
+++ b/app/controllers/members/applications_controller.rb
@@ -1,7 +1,16 @@
 class Members::ApplicationsController < Members::MembersController
   def index
-    @applicants_submitted = User.with_submitted_application
+    @applicants_submitted = User.with_submitted_application.includes(:application).includes(:sponsorships)
     @applicants_started = User.with_started_application
+    @emails_with_no_sponsors = []
+    @emails_with_sponsors = []
+    @applicants_submitted.each do |applicant|
+      if applicant.application.sponsorships.size > 0
+        @emails_with_sponsors << applicant.email
+      else
+        @emails_with_no_sponsors << applicant.email
+      end
+    end
   end
 
   def show

--- a/app/views/members/applications/index.html.haml
+++ b/app/views/members/applications/index.html.haml
@@ -53,7 +53,11 @@
     %a{"data-toggle" => "collapse" , "href" => "#collapseEmails"} Applicant Email Addresses <b class="caret"></b>
   %div.collapse.out#collapseEmails
     %p Don't spam people! Just invite them to DU things :D
+    %h4 Applicants with no sponsors
     %ul.list-unstyled
-      - @applicants_submitted.each do |applicant|
-        - if applicant.email.present?
-          %li= applicant.email
+      - @emails_with_no_sponsors.each do |email|
+        %li= email
+    %h4 Applicants with sponsors
+    %ul.list-unstyled
+      - @emails_with_sponsors.each do |email|
+        %li= email

--- a/spec/controllers/members/applications_controller_spec.rb
+++ b/spec/controllers/members/applications_controller_spec.rb
@@ -9,6 +9,25 @@ describe Members::ApplicationsController do
     @applicant = create(:user, state: :applicant)
   end
 
+  describe "GET index" do
+    before :each do
+      login_as(:voting_member)
+    end
+
+    it "returns a local with a list of not sponsored applicant emails" do
+      unsponsored_application = create(:application)
+      get :index
+      expect(assigns(:emails_with_no_sponsors)).to eq([unsponsored_application.user.email])
+    end
+
+    it "returns a local with a list of sponsored applicant emails" do
+      sponsored_application = create(:application)
+      create(:sponsorship, application: sponsored_application)
+      get :index
+      expect(assigns(:emails_with_sponsors)).to eq([sponsored_application.user.email])
+    end
+  end
+
   describe "GET show" do
     it "redirects if not logged in" do
       get :show, params: { id: @applicant.application.id }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/doubleunion/arooo/issues/318

### What does this code do, and why?

Divides the list of applicant emails on the applicant index page into applicants with sponsors and applicants with no sponsors, so that each list can be easily contacted separately, if need be.

### How is this code tested?

Specs and local manual tests.

### Are any database migrations required by this change?

No.

### Are there any configuration or environment changes needed?

No.

### Screenshots please :)
After these changes:

![Screen Shot 2021-01-24 at 5 06 52 PM](https://user-images.githubusercontent.com/6729309/105651040-8c667000-5e6a-11eb-8dfa-a02f46e0d67d.png)
