### PR TITLE
Update order of GitHub and Google in login page copy to match order of login buttons

### DIFF
--- a/app/views/sessions/login.html.haml
+++ b/app/views/sessions/login.html.haml
@@ -17,5 +17,5 @@
   %p.ib= link_to 'Sign in with Google', google_login_path, class: 'btn btn-primary btn-lg'
 
   - if Configurable[:accepting_applications]
-    %p To start an application, first authenticate with Google or GitHub. If you have any questions, email us at #{ mail_to JOIN_EMAIL }.
+    %p To start an application, first authenticate with GitHub or Google. If you have any questions, email us at #{ mail_to JOIN_EMAIL }.
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/doubleunion/arooo/issues/564

### What does this code do, and why?

Switches the order in our copy of "GitHub and Google" to match the order of the respective buttons.

### How is this code tested?

Local server visual inspection. See screenshots below.

### Are any database migrations required by this change?

No

### Are there any configuration or environment changes needed?

No

### Screenshots please :)

Before:
![Screen Shot 2021-02-21 at 3 32 07 PM](https://user-images.githubusercontent.com/6729309/108642982-4696ca80-745d-11eb-9f14-29e469fc3171.png)


After:
![Screen Shot 2021-02-21 at 3 32 29 PM](https://user-images.githubusercontent.com/6729309/108642983-4991bb00-745d-11eb-9ba3-8eafec61ff07.png)
