### PR TITLE
Require an application to have answers to required questions before it can be submitted

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -21,6 +21,7 @@ class Application < ApplicationRecord
   validates :user_id, presence: true
   validates :state, presence: true
   validate :validate_agreed, if: :submitted?
+  validate :validate_required_profile_fields, if: :submitted?
 
   scope :for_applicant, -> {
     includes(:user)
@@ -139,6 +140,18 @@ class Application < ApplicationRecord
   def validate_agreed
     unless agreed_to_all?
       errors.add(:base, "Please agree to all terms")
+    end
+  end
+
+  def validate_required_profile_fields
+    unless user.profile.reasons.present?
+      errors.add(:base, "Please share why are you interested in joining Double Union")
+    end
+    unless user.profile.feminism.present?
+      errors.add(:base, "Please share your definition of your feminism")
+    end
+    unless user.profile.attendance.present?
+      errors.add(:base, "Please tell us if you've been to DU events or met members")
     end
   end
 

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -171,7 +171,7 @@ describe ApplicationsController do
         let(:profile_params) {
           {
             summary: "lemurs!", reasons: "lemurs!",
-            projects: "lemurs!", skills: "lemurs!", feminism: "lemurs!"
+            projects: "lemurs!", skills: "lemurs!", feminism: "lemurs!", attendance: "oh yeah"
           }
         }
 
@@ -186,8 +186,21 @@ describe ApplicationsController do
           end
         end
 
-        context "missing required fields" do
+        context "missing required application fields" do
           let(:application_params) { {id: application.id, agreement_terms: true} }
+
+          it "should add an error to the flash" do
+            subject
+            expect(flash[:error]).to include "Application not submitted"
+          end
+
+          it "should not submit the application" do
+            expect { subject }.not_to change { application.state }.from("started")
+          end
+        end
+
+        context "missing required profile fields" do
+          let(:profile_params) { { summary: "lemurs!", reasons: "lemur reasonss!" } }
 
           it "should add an error to the flash" do
             subject

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -33,6 +33,10 @@ FactoryBot.define do
 
     factory :applicant do
       state { "applicant" }
+      after(:create) do |applicant|
+        # Set required profile fields for a submitted application
+        applicant.profile.update!(reasons: "reasons", feminism: "feminism", attendance: "attendance")
+      end
     end
 
     factory :admin do

--- a/spec/features/apply_to_du_spec.rb
+++ b/spec/features/apply_to_du_spec.rb
@@ -14,6 +14,8 @@ describe "applying to double union" do
 
     fill_in "Twitter username", with: "@beepboopbeep"
     fill_in "Pronouns", with: "They/Them"
+    fill_in "user_profile_attributes_reasons", with: "42"
+    fill_in "user_profile_attributes_feminism", with: "it's pretty rad"
     fill_in "user_profile_attributes_attendance", with: "I went to the cool thing"
     check "user_application_attributes_agreement_terms"
     check "user_application_attributes_agreement_policies"
@@ -49,6 +51,9 @@ describe "applying to double union" do
 
     fill_in "Pronouns", with: "They/Them"
     fill_in "Twitter username", with: "@beepboopbeep"
+    fill_in "user_profile_attributes_reasons", with: "42"
+    fill_in "user_profile_attributes_feminism", with: "it's pretty rad"
+    fill_in "user_profile_attributes_attendance", with: "I went to the cool thing"
     check "user_application_attributes_agreement_terms"
     check "user_application_attributes_agreement_policies"
     check "user_application_attributes_agreement_female"

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -38,8 +38,7 @@ describe Comment do
 
   it "should be saved for member" do
     comment = Comment.new(body: "hello")
-    user = create(:user, state: :applicant)
-    comment.application = create(:application, user: user)
+    comment.application = create(:application)
     comment.user = create(:user, state: :member)
     expect(comment.save).to be_truthy
   end

--- a/spec/models/sponsorship_spec.rb
+++ b/spec/models/sponsorship_spec.rb
@@ -7,7 +7,7 @@ describe Sponsorship do
   end
 
   describe "relationships" do
-    let(:user) { create :user }
+    let(:user) { create :applicant }
     let(:application) { create :application, user: user }
     let(:sponsorship) { create :sponsorship, user: user, application: application }
 

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -17,7 +17,7 @@ describe Vote do
     vote = Vote.new
 
     vote.user = create(:user, state: :member)
-    vote.application = create(:application, user: create(:user, state: :applicant))
+    vote.application = create(:application)
     vote.value = true
     expect(vote.valid?).to be_falsey
     expect(vote).to have_at_least(1).errors_on(:user)
@@ -27,14 +27,13 @@ describe Vote do
     vote = Vote.new
 
     vote.user = create(:user, state: :voting_member)
-    vote.application = create(:application, user: create(:user, state: :applicant))
+    vote.application = create(:application)
     vote.value = true
     expect(vote.valid?).to be_truthy
   end
 
   it "should validate uniqueness per user and application" do
-    applicant = create(:user, state: :applicant)
-    application = create(:application, user: applicant)
+    application = create(:application)
     voter = create(:user, state: :voting_member)
     create(:vote, application: application, user: voter)
 
@@ -46,10 +45,9 @@ describe Vote do
   end
 
   it "should validate user is not applicant" do
-    applicant = create(:user, state: :applicant)
-    application = create(:application, user: applicant)
+    application = create(:application)
     invalid = Vote.new(application: application,
-                       user: applicant,
+                       user: application.user,
                        value: true)
     expect(invalid.valid?).to be_falsey
     expect(invalid).to have_at_least(1).error_on(:user)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/doubleunion/arooo/issues/565

### What does this code do, and why?

Adds a validation step during submission to ensure that answers to the application questions are not empty. If a field is missing, the user is shown an error message at the top of the page letting them know which field is missing.

### How is this code tested?

Specs and manual testing.

### Are any database migrations required by this change?

No.

### Are there any configuration or environment changes needed?

No.

### Screenshots please :)

With this change, here are screenshots of the error states:

![Screen Shot 2021-02-21 at 4 59 25 PM](https://user-images.githubusercontent.com/6729309/108944832-691d1500-7610-11eb-886d-91104dc54496.png)

![Screen Shot 2021-02-21 at 4 59 37 PM](https://user-images.githubusercontent.com/6729309/108944845-6e7a5f80-7610-11eb-9af4-cdf3f414bc12.png)

![Screen Shot 2021-02-21 at 4 59 51 PM](https://user-images.githubusercontent.com/6729309/108944858-72a67d00-7610-11eb-92fd-8ca84709dc73.png)
