### PR TITLE
Add Configurable field to turn off new application emails (useful for testing the new application flow)

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -77,9 +77,11 @@ class Application < ApplicationRecord
       application.touch :submitted_at
       ApplicationsMailer.confirmation(application).deliver_now
 
-      member_emails = User.all_members.pluck(:email).compact
-      (member_emails << JOIN_EMAIL).each do |email|
-        ApplicationsMailer.notify_member_of_application(application, email).deliver_now
+      if Configurable[:send_new_application_emails]
+        member_emails = User.all_members.pluck(:email).compact
+        (member_emails << JOIN_EMAIL).each do |email|
+          ApplicationsMailer.notify_member_of_application(application, email).deliver_now
+        end
       end
     end
 

--- a/config/configurable.yml
+++ b/config/configurable.yml
@@ -2,6 +2,10 @@ accepting_applications:
   default: true
   type: boolean
 
+send_new_application_emails:
+  default: true
+  type: boolean
+
 application_deadline_warning:
   type: text
 
@@ -10,39 +14,39 @@ voting_member_policy_doc:
 
 onboarding_offboarding_checklist:
   type: text
-  
+
 orientation_signup:
   type: text
 
 # This file controls what config variables you want to be able to allow your users
 # to set, as well as those you'll be able to access from within the application.
-# 
+#
 # If you want to be able to access a string config[:site_title], for example:
-#   
+#
 # site_title:
 #   name: Site Title
 #   type: string
 #   default: My Site
-#   
+#
 # 'name' is the name that appears in the edit form
-# 
+#
 # 'type' can be 'string' for a text field, 'password' for a password field or 'text' for a text area
 #   'type' defaults to 'string'
-# 
+#
 # 'default' is the default value to use if there's no entry in the database. Otherwise, nil will be returned
-# 
+#
 # Some Examples:
-#   
+#
 # site_title:
 #   name: Site Title
 #   default: My Site
 #   type: string
-#   
+#
 # site_description:
 #   name: Description for Google
 #   default: Lots of Awesomeness Here
 #   type: text
-#   
+#
 # secret:
 #   name: Secret Password for Accessing Secret Areas
 #   default: secret

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -16,6 +16,18 @@ describe Application do
       }.to change(ActionMailer::Base.deliveries, :count).by(2)
       expect(application.reload.submitted_at).to be_present
     end
+
+    context "when new application emails are turned off" do
+      before do
+        Configurable[:send_new_application_emails] = false
+      end
+
+      it "only sends an email to the applicant" do
+        expect {
+          application.submit
+        }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+    end
   end
 
   describe "#approve" do


### PR DESCRIPTION
### What github issue is this PR for, if any?

This PR resolves https://github.com/doubleunion/arooo/issues/572 by adding a configuration boolean, accessible to site admins, that can be used to turn off sending of "new application submitted" emails to all members.

This can be used for testing the application flow without spamming the membership.

### How is this code tested?

Added test case.

### Are any database migrations required by this change?

No.

### Are there any configuration or environment changes needed?

No.

### Screenshots please :)

New version of the "Config" section in the app:
(The Configurable gem doesn't seem to let us order those fields in the form, so it looks a little meh, but it is functional.)

![Screen Shot 2021-03-22 at 7 42 03 PM](https://user-images.githubusercontent.com/6729309/112086357-4b789800-8b49-11eb-8316-b3a44649cdc7.png)
