### PR TITLE
Update brakeman to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    brakeman (5.0.1)
+    brakeman (5.0.4)
     bugsnag (6.12.1)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)


### PR DESCRIPTION
Minor version bump for brakeman, which should un-block our build (which requires that we have the latest version of brakeman).