### PR TITLE
Only show current members in door code edit dropdown, show email, and sort alphabetically

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -195,6 +195,12 @@ class User < ApplicationRecord
     general_member? && application.processed_at.present? && application.processed_at <= 14.days.ago
   end
 
+  class << self
+    def all_members_for_dropdown
+      User.all_members.order(name: :asc).collect { |u| ["#{u.name} (#{u.email})", u.id] }
+    end
+  end
+
   private
 
   def gravatar_email

--- a/app/views/admin/door_codes/_form.html.erb
+++ b/app/views/admin/door_codes/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="form-group">
     <%= door_code_form.label :user_id %>
-    <%= door_code_form.select :user_id, User.all.collect { |u| [u.name, u.id] }, { include_blank: true} %>
+    <%= door_code_form.select :user_id, User.all_members_for_dropdown, { include_blank: true} %>
     <p class="help-block">Optional. Use only if you want to assign this code to an existing user.</p>
   </div>
 


### PR DESCRIPTION
For https://github.com/doubleunion/arooo/issues/594, usability improvements to the user drop-down in the door code edit form:
* only show current members (of any kind)
* also show email address (in case a member has no name or a partial name in the database)
* sort alphabetically by name