### PR TITLE
Rename 'blacklisted' status to 'denylisted'

### DIFF
--- a/app/models/door_code.rb
+++ b/app/models/door_code.rb
@@ -10,9 +10,9 @@ class DoorCode < ApplicationRecord
     # This code was previously assigned to a user, and is no longer in the lock.
     # We keep such codes around to avoid code re-use.
     formerly_assigned_not_in_lock: 'formerly_assigned_not_in_lock',
-    # Blacklisted (assumed to not be in the lock).
+    # Denylisted (assumed to not be in the lock).
     # Used for disallowing easily guessable codes.
-    blacklisted: 'blacklisted'
+    denylisted: 'denylisted'
   }
 
   # A code without a user is available for assigning to a member


### PR DESCRIPTION
As part of https://github.com/doubleunion/arooo/issues/594, improve naming of status for disallowed codes.