### PR TITLE
Add a simple legend explaining the meaning of the door code statuses

### DIFF
--- a/app/views/admin/door_codes/_status_legend.html.erb
+++ b/app/views/admin/door_codes/_status_legend.html.erb
@@ -1,22 +1,21 @@
 <div class="container small bg-info">
   <h4>What door code statuses mean</h4>
-  <ul>
-    <li>
-      not_in_lock: code exists in the database, but not in the physical door lock
-    </li>
-    <li>
-      in_lock: code exists in the lock
-    </li>
-    <li>
-      formerly_assigned_in_lock: code used to be assigned to a member, but is no longer assigned;
+  <dl>
+    <dt>not_in_lock</dt>
+    <dd>code exists in the database, but not in the physical door lock</dd>
+    <dt>in_lock</dt>
+    <dd>code exists in the lock</dd>
+    <dt>formerly_assigned_in_lock</dt>
+    <dd>
+      code used to be assigned to a member, but is no longer assigned;
       this code exists in the lock (we probably want to remove it!)
-    </li>
-    <li>
-      formerly_assigned_not_in_lock: code used to be assigned to a member, and is not in the lock;
+    </dd>
+    <dt>formerly_assigned_not_in_lock</dt>
+    <dd>
+      code used to be assigned to a member, and is not in the lock;
       we keep it in the database to prevent code reuse
-    </li>
-    <li>
-      denylisted: we don't allow this code to be used
-    </li>
-  </ul>
+    </dd>
+    <dt>denylisted</dt>
+    <dd>we don't allow this code to be used</dd>
+  </dl>
 </div>

--- a/app/views/admin/door_codes/_status_legend.html.erb
+++ b/app/views/admin/door_codes/_status_legend.html.erb
@@ -1,0 +1,22 @@
+<div class="container small bg-info">
+  <h4>What door code statuses mean</h4>
+  <ul>
+    <li>
+      not_in_lock: code exists in the database, but not in the physical door lock
+    </li>
+    <li>
+      in_lock: code exists in the lock
+    </li>
+    <li>
+      formerly_assigned_in_lock: code used to be assigned to a member, but is no longer assigned;
+      this code exists in the lock (we probably want to remove it!)
+    </li>
+    <li>
+      formerly_assigned_not_in_lock: code used to be assigned to a member, and is not in the lock;
+      we keep it in the database to prevent code reuse
+    </li>
+    <li>
+      denylisted: we don't allow this code to be used
+    </li>
+  </ul>
+</div>

--- a/app/views/admin/door_codes/edit.html.erb
+++ b/app/views/admin/door_codes/edit.html.erb
@@ -1,3 +1,7 @@
 <h1>Edit Door Code</h1>
 
 <%= render partial: 'form', locals: { door_code: door_code} %>
+
+<br/>
+
+<%= render partial: 'status_legend' %>

--- a/app/views/admin/door_codes/index.html.erb
+++ b/app/views/admin/door_codes/index.html.erb
@@ -12,6 +12,8 @@
   There are no door codes in the database yet!
 <% end %>
 
+<%= render partial: 'status_legend' %>
+
 <table class="table table-striped">
   <thead>
     <tr>

--- a/app/views/admin/door_codes/new.html.erb
+++ b/app/views/admin/door_codes/new.html.erb
@@ -1,3 +1,7 @@
 <h1>Add New Door Code</h1>
 
 <%= render partial: 'form', locals: { door_code: door_code} %>
+
+<br/>
+
+<%= render partial: 'status_legend' %>


### PR DESCRIPTION
For https://github.com/doubleunion/arooo/issues/594, add a legend element that explains the meaning of the door code statuses. We can workshop the wording of the text in follow-up changes.