### PR TITLE
Group door codes by status in index table

### DIFF
--- a/app/controllers/admin/door_codes_controller.rb
+++ b/app/controllers/admin/door_codes_controller.rb
@@ -2,7 +2,6 @@ class Admin::DoorCodesController < ApplicationController
   before_action :ensure_admin
 
   def index
-    @door_codes = DoorCode.all.includes(:user).order(created_at: :asc)
   end
 
   def new
@@ -51,5 +50,13 @@ class Admin::DoorCodesController < ApplicationController
 
   helper_method def door_code
     @door_code ||= params.key?(:id) ? DoorCode.find(params[:id]) : DoorCode.new(door_code_params)
+  end
+
+  helper_method def door_codes
+    @door_codes ||= DoorCode.all.includes(:user).order("users.name")
+  end
+
+  helper_method def door_codes_by_status
+    @door_codes_by_status ||= door_codes.group_by(&:status)
   end
 end

--- a/app/views/admin/door_codes/_codes_table.html.erb
+++ b/app/views/admin/door_codes/_codes_table.html.erb
@@ -1,0 +1,28 @@
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Code</th>
+      <th>Status</th>
+      <th>Assigned To</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% door_codes.each do |door_code| %>
+      <tr>
+        <td>
+          <%= door_code.code %>
+        </td>
+        <td>
+          <%= door_code.status %>
+        </td>
+        <td>
+          <%= door_code.user_id.present? ? door_code.user.name : "unassigned"  %>
+        </td>
+        <td>
+          <%= link_to 'Edit', edit_admin_door_code_path(door_code), class: "btn btn-primary"  %>
+        </td>
+      </tr>
+    <% end %>
+  <tbody>
+</table>

--- a/app/views/admin/door_codes/_status_legend.html.erb
+++ b/app/views/admin/door_codes/_status_legend.html.erb
@@ -7,12 +7,12 @@
     <dd>code exists in the lock</dd>
     <dt>formerly_assigned_in_lock</dt>
     <dd>
-      code used to be assigned to a member, but is no longer assigned;
+      code was assigned to a member, but is no longer assigned;
       this code exists in the lock (we probably want to remove it!)
     </dd>
     <dt>formerly_assigned_not_in_lock</dt>
     <dd>
-      code used to be assigned to a member, and is not in the lock;
+      code was assigned to a member, and is no longer in the lock;
       we keep it in the database to prevent code reuse
     </dd>
     <dt>denylisted</dt>

--- a/app/views/admin/door_codes/index.html.erb
+++ b/app/views/admin/door_codes/index.html.erb
@@ -8,37 +8,9 @@
 
 <h2>Existing Door Codes</h2>
 
-<% if @door_codes.empty? %>
-  There are no door codes in the database yet!
-<% end %>
-
 <%= render partial: 'status_legend' %>
 
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th>Code</th>
-      <th>Status</th>
-      <th>Assigned To</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @door_codes.each do |door_code| %>
-      <tr>
-        <td>
-          <%= door_code.code %>
-        </td>
-        <td>
-          <%= door_code.status %>
-        </td>
-        <td>
-          <%= door_code.user_id.present? ? door_code.user.name : "unassigned"  %>
-        </td>
-        <td>
-          <%= link_to 'Edit', edit_admin_door_code_path(door_code), class: "btn btn-primary"  %>
-        </td>
-      </tr>
-    <% end %>
-  <tbody>
-</table>
+<% door_codes_by_status.each do |status, door_codes| %>
+  <h4>Status: <%= status %></h4>
+  <%= render partial: 'codes_table', locals: { door_codes: door_codes } %>
+<% end %>


### PR DESCRIPTION
For https://github.com/doubleunion/arooo/issues/594, group door codes in the index table by status, and update wording in status legend. Also sorted the codes alphabetically by name of the person they are assigned to.