### PR TITLE
Improve display of own door code to members, reject non-numerical or too-short door codes

### DIFF
--- a/app/models/door_code.rb
+++ b/app/models/door_code.rb
@@ -19,6 +19,8 @@ class DoorCode < ApplicationRecord
   belongs_to :user, optional: true
 
   validates :code, presence: true
+  validates :code, numericality: { only_integer: true }
+  validates :code, length: { minimum: 6 }
   validates_uniqueness_of :code, case_sensitive: false
 
   class << self

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
 
   has_one :profile, dependent: :destroy
   has_one :application, dependent: :destroy
-  has_one :door_code, dependent: :destroy
+  has_one :door_code
   has_many :authentications, dependent: :destroy
   has_many :votes, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/app/views/members/users/index.html.haml
+++ b/app/views/members/users/index.html.haml
@@ -1,21 +1,25 @@
 - if current_user.member? || current_user.key_member?
   .mt-20
-    - if current_user.member?
-      = link_to "Become a key member", edit_members_user_key_members_path(current_user), class: "btn btn-default"
-
     - unless current_user.voting_policy_agreement
       = link_to "Become a voting member", edit_members_user_voting_members_path(current_user), class: "btn btn-default"
 
 = render 'bookmarks'
 
-- if current_user.key_member?
-  - if current_user.door_code
-    %p Your door code is: #{current_user.door_code.code}
-  - else
-    %p
-      You don't seem to have a door code set. If you need one, contact
-      =mail_to MEMBERSHIP_EMAIL
-      for help.
+%h3 Space Access
+- if current_user.door_code.present?
+  %p Your door code is #{current_user.door_code.code}
+- elsif current_user.key_member?
+  %p
+    You are a key member, but you don't seem to have a door code set. If you need one, contact
+    =mail_to MEMBERSHIP_EMAIL
+    for help.
+- elsif current_user.member?
+  %p
+    You are not a key member.
+    = link_to "Become a key member", edit_members_user_key_members_path(current_user), class: "btn btn-default"
+- else
+  %p
+    Only members can become key_members with access to the physical space.
 
 - if @all_admins.any?
   %h3 Admins

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -110,7 +110,7 @@ FactoryBot.define do
   end
 
   factory :door_code do
-    sequence(:code) { |n| "#{1000+n}" }
+    sequence(:code) { |n| "#{100000+n}" }
 
     trait :assigned do
       association :user, factory: :key_member

--- a/spec/models/door_code_spec.rb
+++ b/spec/models/door_code_spec.rb
@@ -6,6 +6,14 @@ describe DoorCode do
   describe "validations" do
     it { is_expected.to validate_presence_of(:code) }
     it { is_expected.to validate_uniqueness_of(:code).case_insensitive }
+
+    it "rejects non-numeric codes" do
+      expect(DoorCode.new(code: "asdf").valid?).to be false
+    end
+
+    it "rejects too-short codes" do
+      expect(DoorCode.new(code: "12345").valid?).to be false
+    end
   end
 
   describe ".make_random_code" do
@@ -20,7 +28,7 @@ describe DoorCode do
 
   describe "#status" do
     it "defaults to not_in_lock" do
-      new_door_code = DoorCode.create!(user: create(:user), code: "12345")
+      new_door_code = DoorCode.create!(user: create(:user), code: "123456")
       expect(new_door_code.not_in_lock?).to be true
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -72,13 +72,14 @@ describe User do
     end
 
     context "when member had a door code" do
-      let!(:door_code) { create(:door_code, user: member) }
+      let!(:door_code) { create(:door_code, user: member, status: :in_lock) }
 
       it "unassigns the door code" do
         subject
         door_code.reload
         expect(door_code.user_id).to eq(nil)
         expect(door_code.is_assigned?).to be false
+        expect(door_code.status).to eq("formerly_assigned_in_lock")
       end
     end
   end


### PR DESCRIPTION
For https://github.com/doubleunion/arooo/issues/594, grab-bag of improvements around door codes:
* improve how we show a member their own door code on the Members home page
* ensure that we reject door codes that aren't numerical or that aren't at least 6 digits long