### PR TITLE
Add back info about orientation and key membership

### DIFF
--- a/app/views/applications_mailer/approved.html.haml
+++ b/app/views/applications_mailer/approved.html.haml
@@ -9,6 +9,8 @@
 
       %p Please also sign up for a #{ link_to "New Member Orientation", Configurable[:orientation_signup] } so we can get you set up with your own access to the space!
 
+      %p When you're a new member, you can visit when other people are already in the space (such as during events announced on the mailing list). When you attend a new member orientation, you’ll have the option to become a key member. As a key member you’d be able to enter the space even when other members are not already in the space. There are a number of responsibilities you would accept as a key member, which will be explained in the new member orientation.
+
       %p If you want to be listed publicly as a member (at the bottom of #{ link_to "this page", MEMBERSHIP_URL }), #{ link_to "log in", login_url } to the app and go to "Edit profile" in the right dropdown menu. There's a checkbox there marked "Show name/website/gravatar on public site?"
 
       %p After you fill out #{ link_to "the membership confirmation and setup form", members_user_setup_url(@user.id) }, here are some things the membership coordinators will do for you:


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #538

### What does this code do, and why?

When we didn't have a physical space, I removed related information from the new-member email, since I thought we might reopen membership while virtual. We didn't, and we have a space again, so I added the main info back.

### How is this code tested?


### Are any database migrations required by this change?


### Are there any configuration or environment changes needed?


### Screenshots please :)
