### PR TITLE
Add asterisk at end of door code display

### DIFF
--- a/app/views/members/users/index.html.haml
+++ b/app/views/members/users/index.html.haml
@@ -7,7 +7,7 @@
 
 %h3 Space Access
 - if current_user.door_code.present?
-  %p Your door code is #{current_user.door_code.code}
+  %p Your door code is #{current_user.door_code.code}*
 - elsif current_user.key_member?
   %p
     You are a key member, but you don't seem to have a door code set. If you need one, contact


### PR DESCRIPTION
### What github issue is this PR for, if any?

None

### What does this code do, and why?

When a person goes to DU and enters their key code, they need to press * on the keypad to inform the lock that they have completed entering their code. This adds that to the homepage display of the code, to tell people to press it as part of their code.

### How is this code tested?

I didn't try it locally. I'm hoping that the * is treated as a literal * and not as a code thing. :D

### Are any database migrations required by this change?


### Are there any configuration or environment changes needed?


### Screenshots please :)
