### PR TITLE
Add `index_number` to Door Code

### DIFF
--- a/app/controllers/admin/door_codes_controller.rb
+++ b/app/controllers/admin/door_codes_controller.rb
@@ -45,7 +45,7 @@ class Admin::DoorCodesController < ApplicationController
   def door_code_params
     return {} unless params.key?(:door_code)
 
-    params.require(:door_code).permit(:code, :status, :user_id, :id)
+    params.require(:door_code).permit(:code, :index_number, :status, :user_id, :id)
   end
 
   helper_method def door_code

--- a/app/models/door_code.rb
+++ b/app/models/door_code.rb
@@ -44,12 +44,13 @@ end
 #
 # Table name: door_codes
 #
-#  id         :integer          not null, primary key
-#  code       :string           not null
-#  status     :string           default("not_in_lock"), not null
-#  created_at :datetime
-#  updated_at :datetime
-#  user_id    :integer
+#  id           :integer          not null, primary key
+#  code         :string           not null
+#  index_number :integer
+#  status       :string           default("not_in_lock"), not null
+#  created_at   :datetime
+#  updated_at   :datetime
+#  user_id      :integer
 #
 # Indexes
 #

--- a/app/models/door_code.rb
+++ b/app/models/door_code.rb
@@ -22,6 +22,7 @@ class DoorCode < ApplicationRecord
   validates :code, numericality: { only_integer: true }
   validates :code, length: { minimum: 6 }
   validates_uniqueness_of :code, case_sensitive: false
+  validates_uniqueness_of :index_number, if: -> { index_number.present? }
 
   class << self
     # @return [String] A randomly generated number of the requested length, as a string. May be zero-padded.

--- a/app/views/admin/door_codes/_codes_table.html.erb
+++ b/app/views/admin/door_codes/_codes_table.html.erb
@@ -2,6 +2,7 @@
   <thead>
     <tr>
       <th>Code</th>
+      <th>Index Number</th>
       <th>Status</th>
       <th>Assigned To</th>
       <th></th>
@@ -12,6 +13,9 @@
       <tr>
         <td>
           <%= door_code.code %>
+        </td>
+        <td>
+          <%= door_code.index_number %>
         </td>
         <td>
           <%= door_code.status %>

--- a/app/views/admin/door_codes/_form.html.erb
+++ b/app/views/admin/door_codes/_form.html.erb
@@ -12,6 +12,11 @@
   </div>
 
   <div class="form-group">
+    <%= door_code_form.label "Index #" %>
+    <%= door_code_form.number_field :index_number %>
+  </div>
+
+  <div class="form-group">
     <%= door_code_form.label :status %>
     <%= door_code_form.select :status, DoorCode.statuses.keys.to_a %>
   </div>

--- a/db/migrate/20220129183750_add_index_to_door_code.rb
+++ b/db/migrate/20220129183750_add_index_to_door_code.rb
@@ -1,0 +1,5 @@
+class AddIndexToDoorCode < ActiveRecord::Migration[6.0]
+  def change
+    add_column :door_codes, :index_number, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_06_014929) do
+ActiveRecord::Schema.define(version: 2022_01_29_183750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 2021_12_06_014929) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "status", default: "not_in_lock", null: false
+    t.integer "index_number"
     t.index ["code"], name: "index_door_codes_on_code", unique: true
     t.index ["user_id"], name: "index_door_codes_on_user_id", unique: true
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,6 +111,7 @@ FactoryBot.define do
 
   factory :door_code do
     sequence(:code) { |n| "#{100000+n}" }
+    sequence(:index_number) { |n| n }
 
     trait :assigned do
       association :user, factory: :key_member

--- a/spec/models/door_code_spec.rb
+++ b/spec/models/door_code_spec.rb
@@ -6,6 +6,7 @@ describe DoorCode do
   describe "validations" do
     it { is_expected.to validate_presence_of(:code) }
     it { is_expected.to validate_uniqueness_of(:code).case_insensitive }
+    it { is_expected.to validate_uniqueness_of(:index_number) }
 
     it "rejects non-numeric codes" do
       expect(DoorCode.new(code: "asdf").valid?).to be false


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses https://github.com/doubleunion/arooo/issues/609

### What does this code do, and why?
Adds an integer column, `index_number` to Door Codes, and exposes it in create, edit and show UIs. This attribute is for tracking the "index number" for a code in our lock, which is needed in order to administrate the codes.

The `index_number` is not required but, if set, it is validated to be unique.

### How is this code tested?

Unit tests and manual local testing.

### Are any database migrations required by this change?

Yes.

### Are there any configuration or environment changes needed?

No.

### Screenshots

![Screen Shot 2022-01-29 at 10 55 26 AM](https://user-images.githubusercontent.com/6729309/151673975-775412f8-dfda-430a-82a5-8ace2ccba08f.png)
![Screen Shot 2022-01-29 at 10 55 45 AM](https://user-images.githubusercontent.com/6729309/151673976-4cdb2c80-11f9-4190-8ba3-324b01a7fa20.png)

