### PR TITLE
Make sure that "Become key member" button appears for non-key-members

### DIFF
--- a/app/views/members/users/index.html.haml
+++ b/app/views/members/users/index.html.haml
@@ -6,6 +6,8 @@
 = render 'bookmarks'
 
 %h3 Space Access
+- if current_user.member?
+  = link_to "Become a key member", edit_members_user_key_members_path(current_user), class: "btn btn-default"
 - if current_user.door_code.present?
   %p Your door code is #{current_user.door_code.code}*
 - elsif current_user.key_member?
@@ -13,13 +15,6 @@
     You are a key member, but you don't seem to have a door code set. If you need one, contact
     =mail_to MEMBERSHIP_EMAIL
     for help.
-- elsif current_user.member?
-  %p
-    You are not a key member.
-    = link_to "Become a key member", edit_members_user_key_members_path(current_user), class: "btn btn-default"
-- else
-  %p
-    Only members can become key_members with access to the physical space.
 
 - if @all_admins.any?
   %h3 Admins


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses https://github.com/doubleunion/arooo/issues/605

### What does this code do, and why?
 
Makes sure that a member who is not a key-member always sees the "Become a key member" button on the members' home, even if they already have a door code assigned.

### How is this code tested?

Manual testing locally.

### Are any database migrations required by this change?

No.

### Are there any configuration or environment changes needed?

No.

### Screenshots

**For a member with no door code**
![Screen Shot 2022-01-29 at 11 09 17 AM](https://user-images.githubusercontent.com/6729309/151674406-3a954de3-e788-4034-a97a-8fcce3c96e33.png)

**For a key member that has no assigned door code**
![Screen Shot 2022-01-29 at 11 10 14 AM](https://user-images.githubusercontent.com/6729309/151674414-30ece235-a06d-4750-a0ec-ba80bcc85161.png)

**Edge case that shouldn't happen: for a member who has a door code but is not a key member**
![Screen Shot 2022-01-29 at 11 12 13 AM](https://user-images.githubusercontent.com/6729309/151674422-94bf5886-a25d-4293-980d-ee74ce907bb7.png)

**For a key member that has a door code**
![Screen Shot 2022-01-29 at 11 17 31 AM](https://user-images.githubusercontent.com/6729309/151674543-e338bd25-f9b5-4343-bf48-440dabd34f32.png)


