### PR TITLE
Remove no longer necessary direct dependency on BigDecimal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem "uglifier"
 gem "coffee-rails", ">= 4.2.2"
 gem "bootstrap-sass"
 gem "jquery-datatables-rails", ">= 3.4.0"
-gem "bigdecimal", "3.1.2" # specify this directly to get around the error NoMethodError: undefined method `new' for BigDecimal:Class
 gem "redis" # Used to store recently-authorized doorbell member
 
 # Avoid low-severity security issue: https://github.com/advisories/GHSA-vr8q-g5c7-m54m

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,6 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    bigdecimal (3.1.2)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.4.1)
@@ -412,7 +411,6 @@ DEPENDENCIES
   awesome_print
   aws-sdk-rails (>= 2.1.0)
   better_errors
-  bigdecimal (= 3.1.2)
   binding_of_caller
   bootstrap-sass
   brakeman


### PR DESCRIPTION
Cleaning up some dependencies to make upgrades easier in the future.