### PR TITLE
[BUG] Fix mailer configuration to match new version of aws-sdk-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "bugsnag"
 gem "stripe", "~> 3" # TODO upgrade this! Carefully...
 gem "stripe_event"
 gem "rack-canonical-host"
-gem "aws-sdk-rails", ">= 2.1.0"
+gem "aws-sdk-rails", "~> 3"
 gem "rack-cors"
 gem "haml-rails", ">= 1.0.0"
 gem "sass-rails", ">= 5.0.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -427,7 +427,7 @@ PLATFORMS
 DEPENDENCIES
   annotate
   awesome_print
-  aws-sdk-rails (>= 2.1.0)
+  aws-sdk-rails (~> 3)
   better_errors
   binding_of_caller
   bootstrap-sass

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  config.action_mailer.delivery_method = :aws_sdk
+  config.action_mailer.delivery_method = :ses
   config.action_mailer.default_url_options = {host: ENV["HOST_URL"]}
 
   # Use default logging formatter so that PID and timestamp are not suppressed.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -74,7 +74,7 @@ Doubleunion::Application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  config.action_mailer.delivery_method = :aws_sdk
+  config.action_mailer.delivery_method = :ses
   config.action_mailer.default_url_options = {host: ENV["HOST_URL"]}
 
   # Disable automatic flushing of the log to improve performance.


### PR DESCRIPTION
This change addresses https://github.com/doubleunion/arooo/issues/676 : a recent gem upgrade for `aws-sdk-rails` changed the name of the email "delivery method" it provides, but we didn't update our configuration to match. This PR fixes this.