### PR TITLE
Use consistent language and punctuation on application pages.

### DIFF
--- a/app/views/applications/_show.html.haml
+++ b/app/views/applications/_show.html.haml
@@ -11,36 +11,52 @@
       Email
       %small (required)
     %td= @user.email
+
   %tr
     %td.left
       Pronouns
       %small (optional)
-      %p.small *This does not affect your application. Double Union members want to use your correct pronouns.
+      %p.small *This does not affect your application, we just want to know how to refer to you respectfully.
     %td= @user.profile.pronouns
+
   %tr
-    %td.left Twitter url
+    %td.left
+      Twitter username
+      %small (optional)
     %td= external_auto_link(@user.profile.twitter_url)
 
   %tr
-    %td.left Facebook url
+    %td.left
+      Facebook URL
+      %small (optional)
     %td= external_auto_link(@user.profile.facebook)
 
   %tr
-    %td.left Website url
+    %td.left
+      Website URL
+      %small (optional)
     %td= external_auto_link(@user.profile.website)
 
   %tr
-    %td.left LinkedIn url
+    %td.left
+      LinkedIn URL
+      %small (optional)
     %td= external_auto_link(@user.profile.linkedin)
 
   %tr
-    %td.left Why are you interested in joining Double Union?
+    %td.left
+      Why are you interested in joining Double Union?
+      %small (required)
     %td= markdown(@user.profile.reasons)
 
   %tr
-    %td.left What is your definition of your feminism?
+    %td.left
+      What is your definition of your feminism?
+      %small (required)
     %td= markdown(@user.profile.feminism)
 
   %tr
-    %td.left Have you been to DU events or met DU members?
+    %td.left
+      Have you been to DU events or met DU members?
+      %small (required)
     %td= markdown(@user.profile.attendance)

--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -37,13 +37,13 @@
     %tr
       %td
         = f.label :name, "Full name"
-        %small #{"required"}
+        %small #{"(required)"}
       %td= f.text_field :name, required: true
 
     %tr
       %td
         = f.label :email, "Email"
-        %small #{"required"}
+        %small #{"(required)"}
       %td= f.text_field :email, required: true
 
     = f.fields_for :profile do |profile_fields|
@@ -52,6 +52,7 @@
       %tr
         %td
           = profile_fields.label :pronouns, ("pronouns").capitalize
+          %small #{"(optional)"}
 
           %p.small
             = ("What ")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Cleanup in the files that the change for #487 touches.

### What does this code do, and why?
* On the application edit page, the "required" marking on fields is not enclosed in parentheses, but the "(optional)" marking is in parentheses. This PR changes "required" to "(required)" for consistency.
* On the application show page, not all fields are marked as "required" or "optional". This PR marks all of the fields.
* The explanation for why we ask for pronouns is phrased differently on the edit and show pages. This PR updates the two pages to use the same language.

### How is this code tested?
Locally -- only text changes

### Are any database migrations required by this change?
No

### Are there any configuration or environment changes needed?
No

### Screenshots please :)
#### Before:
Edit page:
![Screenshot 2022-07-17 6 57 17 PM](https://user-images.githubusercontent.com/5607966/179435163-38b9deed-1ab6-4ff3-b90e-10471eaf5837.png)

Show page:
![Screenshot 2022-07-17 6 57 26 PM](https://user-images.githubusercontent.com/5607966/179435171-b4b52805-8cd6-49fa-a241-b1bf2b9990f9.png)

#### After:
Edit page:
![Screenshot 2022-07-17 6 41 35 PM](https://user-images.githubusercontent.com/5607966/179435035-24330938-49b3-4dad-b7d4-2d6786c4f67a.png)

Show page:
![Screenshot 2022-07-17 6 46 53 PM](https://user-images.githubusercontent.com/5607966/179435041-4a1d6e15-7cfb-4310-83a6-33a5988e16cb.png)

