### PR TITLE
Add Google account email to application edit and show pages.

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -65,7 +65,7 @@ class ApplicationsController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email,
+    params.require(:user).permit(:name, :email, :email_for_google,
       profile_attributes: profile_attributes,
       application_attributes: application_attributes)
   end

--- a/app/views/applications/_show.html.haml
+++ b/app/views/applications/_show.html.haml
@@ -10,13 +10,13 @@
     %td.left
       Contact email
       %small (required)
-      %p.small *We will contact you using this email, and we will add this email to the DU mailing list if you get accepted as a member.
+      %p.small *We will use this email to contact you about your application.
     %td= @user.email
   %tr
     %td.left
       Google account email
       %small (optional)
-      %p.small *We use Google Drive and Google Calendar for internal coordination for members. We will use this email to add you to those resources if you get accepted as a member.
+      %p.small *We use Google Calendar, Drive and Groups for internal coordination for members. We will use this email to add you to those resources if you get accepted as a member.
     %td= @user.email_for_google
 
   %tr

--- a/app/views/applications/_show.html.haml
+++ b/app/views/applications/_show.html.haml
@@ -8,9 +8,16 @@
 
   %tr
     %td.left
-      Email
+      Contact email
       %small (required)
+      %p.small *We will contact you using this email, and we will add this email to the DU mailing list if you get accepted as a member.
     %td= @user.email
+  %tr
+    %td.left
+      Google account email
+      %small (optional)
+      %p.small *We use Google Drive and Google Calendar for internal coordination for members. We will use this email to add you to those resources if you get accepted as a member.
+    %td= @user.email_for_google
 
   %tr
     %td.left

--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -42,9 +42,21 @@
 
     %tr
       %td
-        = f.label :email, "Email"
+        = f.label :email, "Contact email"
         %small #{"(required)"}
+
+        %p.small
+          = "We will contact you using this email, and we will add this email to the DU mailing list if you get accepted as a member."
       %td= f.text_field :email, required: true
+
+    %tr
+      %td
+        = f.label :email_for_google, "Google account email"
+        %small #{"(optional)"}
+
+        %p.small
+          = "We use Google Drive and Google Calendar for internal coordination for members. We will use this email to add you to those resources if you get accepted as a member."
+      %td= f.text_field :email_for_google
 
     = f.fields_for :profile do |profile_fields|
       = profile_fields.hidden_field :id

--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -46,7 +46,7 @@
         %small #{"(required)"}
 
         %p.small
-          = "We will contact you using this email, and we will add this email to the DU mailing list if you get accepted as a member."
+          = "We will use this email to contact you about your application."
       %td= f.text_field :email, required: true
 
     %tr
@@ -55,7 +55,7 @@
         %small #{"(optional)"}
 
         %p.small
-          = "We use Google Drive and Google Calendar for internal coordination for members. We will use this email to add you to those resources if you get accepted as a member."
+          = "We use Google Calendar, Drive and Groups for internal coordination for members. We will use this email to add you to those resources if you get accepted as a member."
       %td= f.text_field :email_for_google
 
     = f.fields_for :profile do |profile_fields|

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -126,7 +126,7 @@ describe ApplicationsController do
           id: application.id,
           user:
           {
-            email_for_google: :email_for_google,
+            email_for_google: email_for_google,
             application_attributes: application_params,
             profile_attributes: profile_params
           }
@@ -144,6 +144,7 @@ describe ApplicationsController do
 
         it "should update the user's application" do
           expect { subject }.to change { application.agreement_terms }.from(false).to(true)
+                            .and change { user.email_for_google }.from(nil).to("lemurs@gmail.com")
           expect(response).to redirect_to edit_application_path(application)
         end
 
@@ -187,7 +188,7 @@ describe ApplicationsController do
         }
 
         context "with all required fields" do
-          it "should add an notice to the flash" do
+          it "should add a notice to the flash" do
             subject
             expect(flash[:notice]).to include "Application submitted"
           end
@@ -200,7 +201,7 @@ describe ApplicationsController do
         context "missing optional email for Google" do
           let(:email_for_google) { "" }
 
-          it "should add an notice to the flash" do
+          it "should add a notice to the flash" do
             subject
             expect(flash[:notice]).to include "Application submitted"
           end

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -57,7 +57,7 @@ describe ApplicationsController do
         expect(response).to render_template :show
       end
 
-      it "should not render application of another user" do
+      it "should redirect to root for another user's application" do
         get :show, params: { id: other_user.application.id }
         expect(response).to redirect_to :root
       end
@@ -126,11 +126,13 @@ describe ApplicationsController do
           id: application.id,
           user:
           {
+            email_for_google: :email_for_google,
             application_attributes: application_params,
             profile_attributes: profile_params
           }
         }
       }
+      let(:email_for_google) { "lemurs@gmail.com" }
       let(:profile_params) { {summary: "lemurs!"} }
 
       subject { post :update, params: params }
@@ -145,7 +147,16 @@ describe ApplicationsController do
           expect(response).to redirect_to edit_application_path(application)
         end
 
-        context "missing required fields" do
+        context "missing optional email for Google" do
+          let(:email_for_google) { "" }
+
+          it "should update the user's application" do
+            expect { subject }.to change { application.agreement_terms }.from(false).to(true)
+            expect(response).to redirect_to edit_application_path(application)
+          end
+        end
+
+        context "missing required contact email" do
           before { params.merge!(user: {email: ""}) }
 
           it "should not update the user" do
@@ -176,6 +187,19 @@ describe ApplicationsController do
         }
 
         context "with all required fields" do
+          it "should add an notice to the flash" do
+            subject
+            expect(flash[:notice]).to include "Application submitted"
+          end
+
+          it "should submit the application" do
+            expect { subject }.to change { application.state }.from("started").to("submitted")
+          end
+        end
+
+        context "missing optional email for Google" do
+          let(:email_for_google) { "" }
+
           it "should add an notice to the flash" do
             subject
             expect(flash[:notice]).to include "Application submitted"


### PR DESCRIPTION
### What github issue is this PR for, if any?
#487 

### What does this code do, and why?
Currently, after a new member is accepted, they need to add a Google-friendly email address that we can use for sharing the DU Google Drive and Google Calendar. The membership coordinators often need to remind people to add Google-friendly emails.

This PR moves adding a Google-friendly email into the application process. The Google-friendly email is optional as suggested by Britta in issue #487, in case someone wants to join without a Google address.

This PR lets people fill in this field manually. Britta also suggested in issue #487 that we could try to fill in the Google-friendly email automatically when people log into the DU app with Google. I will look into that separately. We could also consider setting the Google-friendly email to the contact email if it ends in "@gmail.com" (a common kind of Google-friendly email and the only kind that we can identify by looking at the email address -- you can also use Gmail with other domains).

### How is this code tested?
Locally, and updated the specs for the controller

### Are any database migrations required by this change?
No (the email_for_google field already exists in the database and is already set elsewhere in the app)

### Are there any configuration or environment changes needed?
No

### Screenshots please :)

Edit application page:
![Screenshot 2022-07-19 9 07 12 PM](https://user-images.githubusercontent.com/5607966/179894701-e7c3599f-b1c4-4b18-b790-eb9e4b560d2f.png)

Show application page:
![Screenshot 2022-07-19 9 07 19 PM](https://user-images.githubusercontent.com/5607966/179894723-3826fb2d-e4ec-4b05-9b93-62f1ea9e9f33.png)

Saving the application page writes email_for_google to the database:
![Screenshot 2022-07-19 9 00 31 PM](https://user-images.githubusercontent.com/5607966/179894755-e004c0df-05f7-4fac-b745-87954d5d5d9f.png)
