### PR TITLE
Set Google account email automatically when a new applicant logs in with Google OAuth.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -47,6 +47,12 @@ class SessionsController < ApplicationController
     if new_user?
       user = User.create(username: session[:username], email: params[:email])
 
+      # If a new user logged in with Google, set email_for_google to the
+      # email address they used to log in.
+      if session[:email_for_google]
+        user.email_for_google = session[:email_for_google]
+      end
+
       if user.save
         make_auth(user)
         user.make_applicant!
@@ -92,6 +98,9 @@ class SessionsController < ApplicationController
     session[:provider] = omniauth.provider
     session[:uid] = omniauth.uid
     session[:username] = omniauth.try(:username) || omniauth.try(:email)
+    if omniauth.is_a?(GoogleAuth)
+      session[:email_for_google] = omniauth.try(:email)
+    end
   end
 
   def add_auth_and_redirect(omniauth)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -49,7 +49,7 @@ class SessionsController < ApplicationController
 
       # If a new user logged in with Google, set email_for_google to the
       # email address they used to log in.
-      if session[:email_for_google]
+      if session[:email_for_google].present?
         user.email_for_google = session[:email_for_google]
       end
 
@@ -98,9 +98,7 @@ class SessionsController < ApplicationController
     session[:provider] = omniauth.provider
     session[:uid] = omniauth.uid
     session[:username] = omniauth.try(:username) || omniauth.try(:email)
-    if omniauth.is_a?(GoogleAuth)
-      session[:email_for_google] = omniauth.try(:email)
-    end
+    session[:email_for_google] = omniauth.try(:email) if omniauth.is_a?(GoogleAuth)
   end
 
   def add_auth_and_redirect(omniauth)

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -27,130 +27,164 @@ describe SessionsController do
   end
 
   describe "GET google" do
-    it "redirects to github" do
+    it "redirects to google" do
       expect(get(:google)).to redirect_to "/auth/google_oauth2"
     end
   end
 
   describe "GET create" do
-    before do
-      request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:github]
-    end
-
-    subject { get :create, params: { provider: "github" } }
-
-    describe "for a new user" do
-      it "redirects to email confirmation step" do
-        expect(subject).to redirect_to get_email_path
+    describe "with Github authentication" do
+      before do
+        request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:github]
       end
 
-      it "sets omniauth info in cookies" do
-        subject
-        expect(session["uid"]).to eq("12345")
-        expect(session["username"]).to eq("someone")
-        expect(session["provider"]).to eq("github")
-      end
-    end
+      subject { get :create, params: { provider: "github" } }
 
-    describe "with an existing user" do
-      let(:user) { create_with_omniauth(OmniAuth.config.mock_auth[:github]) }
-
-      context "who is a visitor" do
-        it "doesn't make a new user" do
-          expect { subject }.to_not change { User.count }
-        end
-
-        it "makes the visitor an applicant" do
-          expect { subject }.to change { user.reload.state }.from("visitor").to("applicant")
-        end
-
+      describe "for a new user" do
         it "redirects to confirm their email address" do
-          subject
-          expect(response).to redirect_to get_email_path
+          expect(subject).to redirect_to get_email_path
         end
 
-        it "does not create a session for them" do
-          expect { subject }.not_to change { session[:user_id] }
+        it "sets omniauth info in cookies" do
+          subject
+          # These values correspond to the mock Github login defined in
+          # spec/spec_helper.rb.
+          expect(session["uid"]).to eq("12345")
+          expect(session["username"]).to eq("someone")
+          expect(session["provider"]).to eq("github")
+          # email_for_google is not set when a user logs in with Github.
+          expect(session["email_for_google"]).to eq(nil)
         end
       end
 
-      context "who is an applicant" do
-        before { user.update_attribute(:state, "applicant") }
+      describe "with an existing user" do
+        let(:user) { create_with_omniauth(OmniAuth.config.mock_auth[:github]) }
 
-        it "doesn't make a new user" do
-          expect { subject }.to_not change { User.count }
+        context "who is a visitor" do
+          it "doesn't make a new user" do
+            expect { subject }.to_not change { User.count }
+          end
+
+          it "makes the visitor an applicant" do
+            expect { subject }.to change { user.reload.state }.from("visitor").to("applicant")
+          end
+
+          it "redirects to confirm their email address" do
+            subject
+            expect(response).to redirect_to get_email_path
+          end
+
+          it "does not create a session for them" do
+            expect { subject }.not_to change { session[:user_id] }
+          end
         end
 
-        it "creates a session" do
-          subject
-          expect(session[:user_id]).to eq(user.id)
+        context "who is an applicant" do
+          before { user.update_attribute(:state, "applicant") }
+
+          it "doesn't make a new user" do
+            expect { subject }.to_not change { User.count }
+          end
+
+          it "creates a session" do
+            subject
+            expect(session[:user_id]).to eq(user.id)
+          end
+
+          it "redirects to the application edit page" do
+            subject
+            expect(response).to redirect_to edit_application_path(user.application)
+          end
         end
 
-        it "redirects to the application edit page" do
-          subject
-          expect(response).to redirect_to edit_application_path(user.application)
-        end
-      end
+        context "who is a member" do
+          before { user.update_attribute(:state, "member") }
 
-      context "who is a member" do
-        before { user.update_attribute(:state, "member") }
+          it "doesn't make a new user" do
+            expect { subject }.to_not change { User.count }
+          end
 
-        it "doesn't make a new user" do
-          expect { subject }.to_not change { User.count }
-        end
-
-        it "creates a session" do
-          subject
-          expect(session[:user_id]).to eq(user.id)
-        end
-
-        it "redirects to the member root path" do
-          subject
-          expect(response).to redirect_to members_root_path
-        end
-
-        it "creates session for member" do
-          expect { subject }.to_not change { User.count }
-          expect(session[:user_id]).to eq(user.id)
-        end
-
-        context "who is already logged in" do
-          let(:auth) { create :authentication, user: user }
-
-          before do
-            login_as(user)
+          it "creates a session" do
+            subject
+            expect(session[:user_id]).to eq(user.id)
           end
 
           it "redirects to the member root path" do
             subject
             expect(response).to redirect_to members_root_path
           end
+
+          it "creates session for member" do
+            expect { subject }.to_not change { User.count }
+            expect(session[:user_id]).to eq(user.id)
+          end
+
+          context "who is already logged in" do
+            let(:auth) { create :authentication, user: user }
+
+            before do
+              login_as(user)
+            end
+
+            it "redirects to the member root path" do
+              subject
+              expect(response).to redirect_to members_root_path
+            end
+          end
+        end
+      end
+
+      describe "with an existing, logged-in user" do
+        let(:user) { create_with_omniauth(OmniAuth.config.mock_auth[:github]) }
+
+        subject { get :create, params: { provider: "google_oauth2" } }
+
+        before do
+          log_in(user)
+          request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:google_oauth2]
+        end
+
+        it "creates a new authentication for the user" do
+          expect { subject }.to change { user.authentications.count }.from(1).to(2)
+        end
+
+        it "makes a new Google authentication" do
+          subject
+          expect(user.authentications.last.provider).to eq "google_oauth2"
+        end
+
+        it "prints the thing again" do
+          subject
         end
       end
     end
 
-    describe "with an existing, logged-in user" do
-      let(:user) { create_with_omniauth(OmniAuth.config.mock_auth[:github]) }
-
-      subject { get :create, params: { provider: "google_oauth2" } }
-
+    describe "with Google authentication" do
       before do
-        log_in(user)
         request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:google_oauth2]
       end
 
-      it "creates a new authentication for the user" do
-        expect { subject }.to change { user.authentications.count }.from(1).to(2)
+      subject { get :create, params: { provider: "google_oauth2" } }
+
+      describe "for a new user" do
+        it "redirects to confirm their email address" do
+          expect(subject).to redirect_to get_email_path
+        end
+
+        it "sets omniauth info in cookies" do
+          subject
+          # These values correspond to the mock Google login defined in
+          # spec/spec_helper.rb.
+          expect(session["uid"]).to eq("67890")
+          expect(session["username"]).to eq("basil@example.com")
+          expect(session["provider"]).to eq("google_oauth2")
+          expect(session["email_for_google"]).to eq("basil@example.com")
+        end
       end
 
-      it "makes a new Google authentication" do
-        subject
-        expect(user.authentications.last.provider).to eq "google_oauth2"
-      end
-
-      it "prints the thing again" do
-        subject
-      end
+      # We do not test the logic for existing users again for Google, since it
+      # is already tested above for Github and does not depend on the OAuth
+      # provider.
     end
   end
 
@@ -161,18 +195,113 @@ describe SessionsController do
   end
 
   describe "POST confirm_email" do
-    before do
-      session[:username] = "coolcat423"
-      session[:provider] = "github"
-      session[:uid] = "12345"
+    describe "with Github authentication" do
+      # These values correspond to the mock Github login defined in
+      # spec/spec_helper.rb.
+      before do
+        session[:username] = "someone"
+        session[:provider] = "github"
+        session[:uid] = "12345"
+      end
+
+      subject { post :confirm_email, params: { email: email } }
+
+      context "with valid params" do
+        # This email corresponds to the mock Github login defined in
+        # spec/spec_helper.rb.
+        let(:email) { "someone@foo.bar" }
+
+        context "with a new user" do
+          let(:user) { User.last }
+          let(:authentication) { user.authentications.first }
+
+          it "creates user and makes applicant" do
+            expect { subject }.to change { User.count }.from(0).to(1)
+
+            expect(user.applicant?).to be_truthy
+
+            expect(user.username).to eq("someone")
+            expect(user.email).to eq("someone@foo.bar")
+            expect(user.email_for_google).to eq(nil)
+            expect(authentication.provider).to eq("github")
+            expect(authentication.uid).to eq("12345")
+          end
+
+          it "sets the session with the newly-created user" do
+            subject
+            expect(session[:user_id]).to eq(user.id)
+          end
+        end
+
+        context "with an existing user" do
+          let(:user) { create_with_omniauth(OmniAuth.config.mock_auth[:github]) }
+
+          before do
+            user.update_attribute(:state, "member")
+          end
+
+          it "does not create a user" do
+            expect { subject }.not_to change { User.count }
+          end
+
+          it "does not set the session" do
+            subject
+            expect(session[:user_id]).to be_nil
+          end
+
+          it "redirects to the root path" do
+            expect(subject).to redirect_to :root
+          end
+
+          it "sets the flash message" do
+            subject
+            expect(flash[:alert]).to include "It looks like you've previously logged in"
+          end
+        end
+      end
+
+      context "with a bad email address" do
+        let(:email) { "someone" }
+
+        it "rerenders the page" do
+          expect(subject).to render_template :get_email
+        end
+
+        it "does not set the session" do
+          subject
+          expect(session[:user_id]).to be_nil
+        end
+      end
+
+      context "with no email address" do
+        let(:email) { "" }
+
+        it "rerenders the page" do
+          expect(subject).to render_template :get_email
+        end
+
+        it "does not set the session" do
+          subject
+          expect(session[:user_id]).to be_nil
+        end
+      end
     end
 
-    subject { post :confirm_email, params: { email: email } }
+    describe "with Google authentication" do
+      # In a real login with Google, username, email, and email_for_google
+      # would all have the same value. Here we tag them to make sure that
+      # each value in the session is written to the right place in the model.
+      before do
+        session[:username] = "basil+username@example.com"
+        session[:provider] = "google_oauth2"
+        session[:uid] = "67890"
+        session[:email_for_google] = "basil+google@example.com"
+      end
 
-    context "with valid params" do
-      let(:email) { "someone@foo.bar" }
+      subject { post :confirm_email, params: { email: email } }
 
       context "with a new user" do
+        let(:email) { "basil+email@example.com" }
         let(:user) { User.last }
         let(:authentication) { user.authentications.first }
 
@@ -181,68 +310,17 @@ describe SessionsController do
 
           expect(user.applicant?).to be_truthy
 
-          expect(user.username).to be_present
-          expect(authentication.provider).to be_present
-          expect(authentication.uid).to be_present
-        end
-
-        it "sets the session with the newly-created user" do
-          subject
-          expect(session[:user_id]).to eq(user.id)
-        end
-      end
-
-      context "with an existing user" do
-        let(:user) { create_with_omniauth(OmniAuth.config.mock_auth[:github]) }
-
-        before do
-          user.update_attribute(:state, "member")
-        end
-
-        it "does not create a user" do
-          expect { subject }.not_to change { User.count }
-        end
-
-        it "does not set the session" do
-          subject
-          expect(session[:user_id]).to be_nil
-        end
-
-        it "redirects to the root path" do
-          expect(subject).to redirect_to :root
-        end
-
-        it "sets the flash message" do
-          subject
-          expect(flash[:alert]).to include "It looks like you've previously logged in"
+          expect(user.username).to eq("basil+username@example.com")
+          expect(user.email).to eq("basil+email@example.com")
+          expect(user.email_for_google).to eq("basil+google@example.com")
+          expect(authentication.provider).to eq("google_oauth2")
+          expect(authentication.uid).to eq("67890")
         end
       end
     end
 
-    context "with a bad email address" do
-      let(:email) { "someone" }
-
-      it "rerenders the page" do
-        expect(subject).to render_template :get_email
-      end
-
-      it "does not set the session" do
-        subject
-        expect(session[:user_id]).to be_nil
-      end
-    end
-
-    context "with no email address" do
-      let(:email) { "" }
-
-      it "rerenders the page" do
-        expect(subject).to render_template :get_email
-      end
-
-      it "does not set the session" do
-        subject
-        expect(session[:user_id]).to be_nil
-      end
-    end
+    # We do not test the logic for existing users again for Google, since it
+    # is already tested above for Github and does not depend on the OAuth
+    # provider.
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #487.

### What does this code do, and why?
I added a Google account email to the application form in pull #696.

This PR sets the new Google account email field automatically if a new applicant logs in with Google OAuth, as Britta suggested in issue #487.

### How is this code tested?
Manually and with specs.

### Are any database migrations required by this change?
No (the email_for_google field already exists and is set in other places in the app)

### Are there any configuration or environment changes needed?
No

### Screenshots please :)
#### When logging in with Google for the first time:

1. I have to enter a contact email to get to the application page:
  ![Screenshot 2022-07-30 8 42 41 PM](https://user-images.githubusercontent.com/5607966/182008942-149efebd-46a5-46f3-b13c-d65b7c396b44.png)

2. On the application page, "Google account email" is already filled in, to the email address I used to log in with Google:
  ![Screenshot 2022-07-30 8 44 58 PM](https://user-images.githubusercontent.com/5607966/182008993-af52a6a0-a466-47c3-92a1-c8689091d6a9.png)

3. email_for_google is already set in the database from the OAuth login, before I save the application:
  ![Screenshot 2022-07-30 8 46 22 PM](https://user-images.githubusercontent.com/5607966/182009050-0a621560-10ea-4180-b182-f005f9233629.png)

#### When logging in with Github for the first time:

1. I have to enter a contact email to get to the application page:
  ![Screenshot 2022-07-30 8 49 19 PM](https://user-images.githubusercontent.com/5607966/182009124-ae0f8371-0a74-4880-9712-3b16792de8fd.png)

2. On the application page, "Google account email" is not set yet, as expected since I logged in with Github:
  ![Screenshot 2022-07-30 8 49 27 PM](https://user-images.githubusercontent.com/5607966/182009166-291b4ffd-177f-4369-af24-c450e4aa44e1.png)

3. email_for_google is also not set in the database yet, as expected since I logged in with Github:
  ![Screenshot 2022-07-30 8 49 56 PM](https://user-images.githubusercontent.com/5607966/182009193-7d10f11c-8e44-4cb2-87ba-878ab37a7602.png)
 