### PR TITLE
Move block of social media links to the bottom of the application form.

### DIFF
--- a/app/assets/stylesheets/membership_application.scss
+++ b/app/assets/stylesheets/membership_application.scss
@@ -11,15 +11,6 @@ body.applications.edit, body.applications.update {
     }
   }
 
-  tr.nested-table {
-    > td {
-      padding-left: 0;
-      padding-right: 0;
-    }
-    table td {
-      border: 0;
-    }
-  }
   .checkbox-label {
     cursor: pointer;
     font-weight: normal;

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -33,3 +33,7 @@
 .hidden {
   display: none;
 }
+
+.bold {
+  font-weight: bold;
+}

--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -75,34 +75,6 @@
 
       %tr
         %td
-          = profile_fields.label :twitter, "Twitter username"
-          %small
-            = "(optional)"
-        %td= profile_fields.text_field :twitter
-
-      %tr
-        %td
-          = profile_fields.label :facebook, "Facebook URL"
-          %small
-            = "(optional)"
-        %td= profile_fields.text_field :facebook
-
-      %tr
-        %td
-          = profile_fields.label :website, "Website URL"
-          %small
-            = "(optional)"
-        %td= profile_fields.text_field :website
-
-      %tr
-        %td
-          = profile_fields.label :linkedin, "LinkedIn URL"
-          %small
-            = "(optional)"
-        %td= profile_fields.text_field :linkedin
-
-      %tr
-        %td
           = profile_fields.label :reasons, "Why are you interested in joining Double Union?"
           %p.small
             = "We ask this because we'd like to learn about how your interests relate to DU. For example, what would you like to work on here, or what would you like to learn or share here? What about DU’s community appeals to you?"
@@ -140,7 +112,39 @@
             = "Required — 2000 character maximum."
         %td= profile_fields.text_area :attendance, rows: 10
 
-      %tr.nested-table
+      %tr
+        %td{ colspan: 2 }
+          %table
+            %tr
+              %td
+                %p.bold= "Social media or website links"
+                %p.small= "Completely optional and only for us to get to know you better. Feel free to share all, some, or none of these links."
+            %tr
+              %td
+                = profile_fields.label :twitter, "Twitter username"
+                %small #{"(optional)"}
+              %td
+                = profile_fields.text_field :twitter
+            %tr
+              %td
+                = profile_fields.label :facebook, "Facebook URL"
+                %small #{"(optional)"}
+              %td
+                = profile_fields.text_field :facebook
+            %tr
+              %td
+                = profile_fields.label :website, "Website URL"
+                %small #{"(optional)"}
+              %td
+                = profile_fields.text_field :website
+            %tr
+              %td
+                = profile_fields.label :linkedin, "LinkedIn URL"
+                %small #{"(optional)"}
+              %td
+                = profile_fields.text_field :linkedin
+
+      %tr
         %td{ colspan: 2 }
           %table
             = f.fields_for :application do |app_fields|


### PR DESCRIPTION
### What github issue is this PR for, if any?
#562

### What does this code do, and why?
Move the block of social media links in the application form to the bottom of the form, as suggested in https://github.com/doubleunion/arooo/issues/562.

I also removed the nested-table style from the stylesheet for this page. It was only used for the nested table that contains the checkboxes at the end of the form. I think the nested table with the checkboxes looks slightly better without this style (the checkboxes are better aligned with the other form items -- see screenshots). Additionally, the new nested table for the social media links does not look good with the nested-table style, and it would be confusing to have a nested-table style that is used for one of these nested tables but not the other.

### How is this code tested?
Locally -- UI changes only.

### Are any database migrations required by this change?
No

### Are there any configuration or environment changes needed?
No

### Screenshots please :)
#### Before:
Social media links at the top of the application:
![Screenshot 2022-08-14 10 44 07 AM](https://user-images.githubusercontent.com/5607966/184548804-5d4e206e-5292-4268-af22-6abffba02748.png)

Checkboxes at the end of the application, with the nested-table style (note that the checkboxes start further left than the other application questions):
![Screenshot 2022-08-14 10 44 14 AM](https://user-images.githubusercontent.com/5607966/184548816-a36f2898-1e36-48d1-a164-2ace1f97411a.png)

#### After:
Social media links at the end of the application, and checkboxes without the nested-table style (note that the checkboxes are aligned with the other application questions):
![Screenshot 2022-08-14 10 39 50 AM](https://user-images.githubusercontent.com/5607966/184548793-9b9fe718-7e0a-4d97-b348-597708926c3d.png)

