### PR TITLE
Remove feature for previewing unsubmitted applications and clarify intro text in application form.

### DIFF
--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -6,15 +6,7 @@
   #{ mail_to JOIN_EMAIL }.
 
 %p
-  = "You can save this application at any time before you submit it. Once submitted, the content will be readable by all current Double Union members. No part of this application will ever be public."
-
-%p
-  = "A small tip: The paragraph questions are parsed as markdown! "
-  #{ link_to "Here's a", "https://caleorourke.gitbooks.io/redcarpet-syntax/content/cheatsheet/index.html", target: "_blank"}
-  = " markdown syntax cheatsheet."
-  = "That means that you can also just type in sentences or paragraphs and it'll look fine, too. You can also "
-  #{ link_to "preview your application", application_path(@user.application), target: "_blank"}
-  = " before or after submitting it."
+  = "You can save this application at any time before you submit it. Once you submit your application, it will be visible to all current Double Union members while it is open, then hidden once it is accepted or rejected. No part of your application will ever be public."
 
 %p
   = "If this application looks blanker than you left it, double check that you logged in with the same service as before by logging out and trying the other one (GitHub or Google)."
@@ -178,9 +170,6 @@
       = "Submit"
     %p
       = "When you're done with your application, submit it with the button below. You will be able to edit it any time before the membership drive closes."
-    %p
-      = "If you're curious what your application will look like to us, you can "
-      #{ link_to "check it out here", application_path(@user.application), target: "_blank"}.
 
     %fieldset
       = f.submit "Submit application", name: 'submit', class: "btn btn-primary"


### PR DESCRIPTION
### What github issue is this PR for, if any?
#562 

### What does this code do, and why?
As suggested in issue #562, this PR:
* Removes the feature that lets applicants preview their unsubmitted applications
* Removes the explanatory text about using markdown to format an application
* Clarifies application visibility -- applications are visible to all current DU members while they are open, then they are no longer visible once they have been accepted or rejected.

### How is this code tested?
Locally -- only UI changes.

### Are any database migrations required by this change?
No

### Are there any configuration or environment changes needed?
No

### Screenshots please :)

#### Unsubmitted application:
Top of page (preview link and text about markdown removed; application visibility clarified):
![Screenshot 2022-08-14 1 16 05 PM](https://user-images.githubusercontent.com/5607966/184553734-67591ac1-0f61-46d1-9fba-1a810499e101.png)

Bottom of page (preview link removed):
![Screenshot 2022-08-14 1 16 15 PM](https://user-images.githubusercontent.com/5607966/184553823-33bd3317-b76b-48ec-8f96-b665dc8b1dfe.png)

#### Submitted application:
Once an application is submitted, you can still use "View application" to see how the application will look to voting members. This behavior existed before and I did not remove it. We can remove it if it's confusing / not useful.
![Screenshot 2022-08-14 1 30 31 PM](https://user-images.githubusercontent.com/5607966/184553866-ecc2aba1-dd8f-4a29-a4c0-5517b53cdd41.png)

"View application" takes you to this page:
![Screenshot 2022-08-14 1 18 14 PM](https://user-images.githubusercontent.com/5607966/184553893-8d5b2f22-2f11-414c-a940-d927e8ffcd9d.png)