### PR TITLE
Update checkbox about assumptions, benefits, and responsibilities in application form.

### DIFF
--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -152,7 +152,7 @@
 
               %tr
                 %td.pt-10= app_fields.check_box :agreement_terms
-                %td.pt-10.pl-10= app_fields.label :agreement_terms, "#{"I understand the"} #{link_to "privileges and responsibilities", MEMBERSHIP_URL, target: "_blank"} #{"that come with Double Union membership."}".html_safe, class: 'checkbox-label'
+                %td.pt-10.pl-10= app_fields.label :agreement_terms, "#{"I have read the"} #{link_to "base assumptions", BASE_ASSUMPTIONS_URL, target: "_blank"} #{"for Double Union and the list of"} #{link_to "benefits and responsibilities", MEMBERSHIP_BENEFITS_RESPONSIBILITIES_URL, target: "_blank"} #{"that come with Double Union membership."} ".html_safe, class: 'checkbox-label'
 
               %tr
                 %td.pt-10= app_fields.check_box :agreement_policies

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -20,6 +20,7 @@ EXTERNAL_SITE_URL = "https://www.doubleunion.org"
 BASE_ASSUMPTIONS_URL = EXTERNAL_SITE_URL + "/base_assumptions"
 POLICIES_URL = EXTERNAL_SITE_URL + "/policies"
 MEMBERSHIP_URL = EXTERNAL_SITE_URL + "/membership"
+MEMBERSHIP_BENEFITS_RESPONSIBILITIES_URL = MEMBERSHIP_URL + "/#membership-benefits-and-responsibilities"
 
 VOTING_CRITERIA_DOC = "https://docs.google.com/document/d/12R7utXAiyCK55XEP8cPscUqu2CXAj-hL5jXE-MaJdgE/edit#heading=h.w83btzy2bttc"
 COMMENTING_DOC = "https://docs.google.com/document/d/12R7utXAiyCK55XEP8cPscUqu2CXAj-hL5jXE-MaJdgE/edit#heading=h.qmgkosbaknlv"


### PR DESCRIPTION
### What github issue is this PR for, if any?
#562

### What does this code do, and why?
As suggested in github.com/doubleunion/arooo/issues/562, this PR updates the checkboxes at the end of the application to:
* Ask applicants to read and acknowledge the base assumptions
* Link directly to the "Membership Benefits and Responsibilities" section on the public website, instead of the top of the membership page
* Clarify that applicants need to read the base assumptions and membership benefits and responsibilities, and be generally ok with them, but it's fine if they don't understand them completely yet.

### How is this code tested?
Locally -- UI changes only.

### Are any database migrations required by this change?
No

### Are there any configuration or environment changes needed?
I think so but am not certain (not familiar with Rails). This change adds a value to config/initializers/constants.rb, and I think this counts as a configuration change that will require restarting the server.

### Screenshots please :)
![Screenshot 2022-08-14 2 38 08 PM](https://user-images.githubusercontent.com/5607966/184556194-1124b1ea-32d4-4056-bfb4-714ae08bc17e.png)

