### PR TITLE
bugfix: for changing from key_member to voting_member removed key code

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,7 +120,7 @@ class User < ApplicationRecord
       user.update(voting_policy_agreement: false)
     end
 
-    after_transition on: all - [:key_member, :make_voting_member] do |user, _|
+    after_transition on: all - [:make_key_member, :make_voting_member] do |user, _|
       user.door_code.unassign if user.door_code.present?
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,7 +116,7 @@ class User < ApplicationRecord
       transition [:member, :voting_member, :key_member] => :former_member
     end
 
-    after_transition on: [:make_member, :make_key_member, :make_former_member] do |user, _|
+    after_transition on: all - [:make_voting_member] do |user, _|
       user.update(voting_policy_agreement: false)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,7 +120,7 @@ class User < ApplicationRecord
       user.update(voting_policy_agreement: false)
     end
 
-    after_transition on: all - [:key_member] do |user, _|
+    after_transition on: all - [:key_member, :make_voting_member] do |user, _|
       user.door_code.unassign if user.door_code.present?
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -134,6 +134,17 @@ describe User do
         expect { subject }.not_to change { member.state }
       end
     end
+
+    context "voting member with a key_code" do
+      let(:member) { create :voting_member }
+      let!(:door_code) { create(:door_code, user: member) }
+      it "transition to key_member does not disable their door code; key code should still be assigned" do
+        subject
+        door_code.reload
+        expect(door_code.user_id).not_to eq(nil)
+        expect(door_code.is_assigned?).to be true
+      end
+    end
   end
 
   describe "#make_voting_member" do
@@ -146,7 +157,6 @@ describe User do
     end
 
     context "was a key member" do
-      let(:member) { create(:key_member) }
       let!(:door_code) { create(:door_code, user: member) }
 
       it "does not disable their door code; key code should still be assigned" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -144,6 +144,18 @@ describe User do
     it "should transition from key member to voting member" do
       expect { subject }.to change { member.state }.from("key_member").to("voting_member")
     end
+
+    context "was a key member" do
+      let(:member) { create(:key_member) }
+      let!(:door_code) { create(:door_code, user: member) }
+
+      it "does not disable their door code; key code should still be assigned" do
+        subject
+        door_code.reload
+        expect(door_code.user_id).not_to eq(nil)
+        expect(door_code.is_assigned?).to be true
+      end
+    end
   end
 
   describe "#door_code" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -115,18 +115,6 @@ describe User do
   end
 
   describe "#make_key_member" do
-    let(:member) { create :voting_member }
-
-    subject { member.make_key_member }
-
-    it "should transition from voting_member to member" do
-      expect { subject }.to change { member.state }.from("voting_member").to("key_member")
-    end
-
-    it "should remove voting member agreement status" do
-      expect { subject }.to change { member.voting_policy_agreement }.from(true).to(false)
-    end
-
     context "with an applicant" do
       let(:member) { create :applicant }
 
@@ -138,6 +126,17 @@ describe User do
     context "voting member with a key_code" do
       let(:member) { create :voting_member }
       let!(:door_code) { create(:door_code, user: member) }
+
+      subject { member.make_key_member }
+
+      it "should transition from voting_member to member" do
+        expect { subject }.to change { member.state }.from("voting_member").to("key_member")
+      end
+
+      it "should remove voting member agreement status" do
+        expect { subject }.to change { member.voting_policy_agreement }.from(true).to(false)
+      end
+
       it "transition to key_member does not disable their door code; key code should still be assigned" do
         subject
         door_code.reload

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -115,6 +115,15 @@ describe User do
   end
 
   describe "#make_key_member" do
+    context "as a member" do
+      let(:member) { create :member }
+      subject { member.make_key_member }
+
+      it "should transition from member to key_member" do
+        expect { subject }.to change { member.state }.from("member").to("key_member")
+      end
+    end
+
     context "with an applicant" do
       let(:member) { create :applicant }
 
@@ -129,7 +138,7 @@ describe User do
 
       subject { member.make_key_member }
 
-      it "should transition from voting_member to member" do
+      it "should transition from voting_member to key_member" do
         expect { subject }.to change { member.state }.from("voting_member").to("key_member")
       end
 


### PR DESCRIPTION

### What github issue is this PR for, if any?
None

### What does this code do, and why?
If transitioning from key_member to voting_member the key_code is not removed.


### How is this code tested?
Added a test


### Are any database migrations required by this change?
No

### Are there any configuration or environment changes needed?
No

### Screenshots please :)
