### PR TITLE
Update outdated description

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
     if content_for?(:title)
       yield(:title)
     else
-      "Double Union | A hacker/maker space for women in San Francisco"
+      "Double Union | A hacker/maker space for nonbinary people and women in San Francisco"
     end
   end
 
@@ -29,7 +29,7 @@ module ApplicationHelper
     if content_for?(:description)
       yield(:description)
     else
-      "A hacker/maker space for women in San Francisco"
+      "A hacker/maker space for nonbinary people and women in San Francisco"
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
None

### What does this code do, and why?
When I paste links to DU app pages into Slack, the automatic description is outdated. I updated it.

### How is this code tested?
I don't know

### Are any database migrations required by this change?
None

### Are there any configuration or environment changes needed?
None

### Screenshots please :)
