### PR TITLE
Give context for dues suggestions

### DIFF
--- a/app/views/members/dues/show.html.haml
+++ b/app/views/members/dues/show.html.haml
@@ -27,11 +27,13 @@
 - else
   %p You don't have a Stripe subscription yet, or it may have been canceled. Please add your credit or debit card, or request a scholarship below! <3
 
-  %p On average members give $30 / month, but please select whatever you can afford. Your dues go directly towards sustaining the space, such as paying for rent, buying supplies, and maintaining our tools.
+  %p Your dues go directly towards sustaining the space, such as paying for rent, buying supplies, and maintaining our tools.
 
 = render 'form', action: "Update"
 
 %h4 Suggestions
+
+%p Our #{ link_to "monthly expenses", "https://docs.google.com/spreadsheets/d/1qkbssNK_u8PnT1jK0eE4isaHkaHBSjiMHFIRlKet22g/edit#gid=1934044271", target: "_blank" } are about $2900.
 
 %table{:width=>"100%"}
   %tr

--- a/app/views/members/users/setup.html.haml
+++ b/app/views/members/users/setup.html.haml
@@ -25,7 +25,7 @@
 %h3 Step Two: Set Up Monthly Dues
 
 %p
-  Most DU members pay monthly dues, which supports the existence of the space.
+  Most DU members pay monthly dues, which supports the existence of the space. Our #{ link_to "monthly expenses", "https://docs.google.com/spreadsheets/d/1qkbssNK_u8PnT1jK0eE4isaHkaHBSjiMHFIRlKet22g/edit#gid=1934044271", target: "_blank" } are about $2900. 
   This is on a sliding scale from $10-$100 — you pay the amount that is right for you, and you can change it at any time (up or down) if your financial situation changes.
 
 %p


### PR DESCRIPTION
### What github issue is this PR for, if any?

None

### What does this code do, and why?

On the dues setup page and manage dues page, I added information about DU's average monthly expenses and a link to our mini budget sheet.

I watched @rayramsay go through the membership setup today, including finding the suggested dues table a bit surprising. We discussed the context (DU's expenses and income), which was helpful. So I figure this information may be helpful for other new members as well.

### How is this code tested?

It's not

### Are any database migrations required by this change?

No

### Are there any configuration or environment changes needed?

No

### Screenshots please :)
