### PR TITLE
Remove configurable for orientation signup link.

### DIFF
--- a/app/views/admin/applications.html.haml
+++ b/app/views/admin/applications.html.haml
@@ -9,8 +9,6 @@
 
     %p Clicking "Approve" makes the person a member, sends them an email notifying them*, and moves them into the New Member page, where the membership coordinators help get them set up.
     
-    %p <em>*You need to #{ link_to "configure an orientation signup link", admin_configurable_path }! The automated email gives the new member that link to sign up for an orientation session. If that link is blank, the email won't get sent.</em>
-
     %p Clicking "Reject" marks the person's application as rejected, but doesn't do anything else. Rejection emails are still a manual process from the membership@ email address.
 
 %h3 Applications to Approve

--- a/app/views/applications_mailer/approved.html.haml
+++ b/app/views/applications_mailer/approved.html.haml
@@ -7,7 +7,7 @@
 
       %p In order to confirm your membership, log into #{ link_to "the site", EXTERNAL_SITE_URL } ("Log in" is at top right) and complete the setup #{ link_to "on this page", members_user_setup_url(@user.id) }. This is where you'll give us your Google-friendly email address for our calendar and mailing list, and set up dues (or apply for a scholarship). (After you’ve done this, a membership coordinator will subscribe you to the mailing list and invite you to Slack. Feel free to start a thread introducing yourself and jump into conversations right away!)
 
-      %p Please also sign up for a #{ link_to "New Member Orientation", Configurable[:orientation_signup] } so we can get you set up with your own access to the space!
+      %p The membership coordinator will reach out to schedule a new member orientation for you, so we can get you set up with your own access to the space! Feel free to email the membership coordinator at #{ mail_to MEMBERSHIP_EMAIL } if you do not hear from them soon.
 
       %p When you're a new member, you can visit when other people are already in the space (such as during events announced on the mailing list). When you attend a new member orientation, you’ll have the option to become a key member. As a key member you’d be able to enter the space even when other members are not already in the space. There are a number of responsibilities you would accept as a key member, which will be explained in the new member orientation.
 
@@ -19,7 +19,7 @@
         %li Give you access to the Double Union Mailing List
         %li Give you access to the Double Union Google Drive folder and Google Calendar
         %li Give you access to the Double Union Slack chat
-        %li Tell you when the new member orientation meetings will be
+        %li Schedule a new member orientation for you
 
       %p If you have any questions, email the membership coordinator at #{ mail_to MEMBERSHIP_EMAIL }.
 

--- a/config/configurable.yml
+++ b/config/configurable.yml
@@ -15,9 +15,6 @@ voting_member_policy_doc:
 onboarding_offboarding_checklist:
   type: text
 
-orientation_signup:
-  type: text
-
 # This file controls what config variables you want to be able to allow your users
 # to set, as well as those you'll be able to access from within the application.
 #

--- a/spec/mailers/applications_mailer_spec.rb
+++ b/spec/mailers/applications_mailer_spec.rb
@@ -40,7 +40,6 @@ describe ApplicationsMailer do
 
   describe "when someone is accepted" do
     before do
-      Configurable[:orientation_signup] = "http://fake.orientation"
       application.approve
     end
 
@@ -48,10 +47,6 @@ describe ApplicationsMailer do
 
     it "is sent to the applicant" do
       expect(mail.to).to include(application.user.email)
-    end
-
-    it "includes a link to orientiation signup" do
-      expect(mail.body).to include("http://fake.orientation")
     end
   end
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -36,11 +36,6 @@ describe Application do
 
     subject { application.approve }
 
-    before do
-      # We need to have an orientation_signup configured for emails to work
-      Configurable[:orientation_signup] = "http://fake.orientation"
-    end
-
     it "sends an email to the applicant" do
       expect { subject }.to change(ActionMailer::Base.deliveries, :count).by(1)
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
None -- discussed during the virtual membership committee meeting today, and did not file an issue.

### What does this code do, and why?
We have a rolling application process now, so we won't do one batch of orientations all at once that all new members should sign up for. I think it would be hard to keep an orientation signup page up to date as new members apply throughout the year, and it would probably be easier to have the membership coordinator handle scheduling orientations for new members as needed.

### How is this code tested?
Unit tests.

Also ran the code in my local environment, but I think the local environment doesn't actually send emails. When I approve an application, the server logs that it's sending an email and logs the contents of the email to the console (screenshot below), but no email is actually sent.

### Are any database migrations required by this change?
No

### Are there any configuration or environment changes needed?
No

### Screenshots please :)
Screenshot of the email that was logged to the console when I approved an application (with HTML formatting, it should look nicer in people's inboxes):
![Screenshot 2023-02-01 9 34 05 PM](https://user-images.githubusercontent.com/5607966/216240798-bc34b5ca-a999-4f93-8005-b41f117fd047.png)