### PR TITLE
Change handbook link on members homepage to key code orientation link.

### DIFF
--- a/app/views/members/users/_bookmarks.html.haml
+++ b/app/views/members/users/_bookmarks.html.haml
@@ -3,7 +3,7 @@
   %ul
     %li #{ link_to "Members mailing list", "https://groups.google.com/a/doubleunion.org/forum/#!forum/members", target: "_blank" }
     %li #{ link_to "Members folder in Google Drive", "https://drive.google.com/folderview?id=0B6a_aDP-2fOVV2FQLW5FVTZ2Mjg", target: "_blank" } &mdash; For easy access,  #{ link_to "add a shortcut in your own Google Drive", "https://support.google.com/drive/answer/2375057?hl=en", target: "_blank" }.
-    %li #{ link_to "Members Handbook", "https://docs.google.com/document/d/1yYXAj8rzQMiYt2xFdzm2xEOe0LCHohWNrMWzad-4mtQ/edit", target: "_blank" } &mdash; This will include space entry instructions when we have a physical space again.
+    %li #{ link_to "Key code orientation", "https://docs.google.com/presentation/d/1ygUBN_4SqZSjDi3Sx8MPviAXQz5KdI6_IOstW9qtWzQ/edit", target: "_blank" } &mdash; Describes how to get access to the 77 Falmouth space, and how to enter the space.
     %li #{ link_to "Members calendar", "https://www.google.com/calendar/embed?src=br12b81lfe63rggddlg0k92mko@group.calendar.google.com&ctz=America/Los_Angeles", target: "_blank" } &mdash; This is a view-only version of the calendar. To add or edit events, go to #{ link_to "Google Calendar", "https://calendar.google.com/calendar/", target: "_blank" } (it should show up among your calendars).
     %li #{ link_to "Members Slack chat", "https://doubleunion.slack.com/", target: "_blank" }
     %li #{ link_to "DU web application code on GitHub", "https://github.com/doubleunion", target: "_blank" }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Didn't file an issue.

### What does this code do, and why?
Change the handbook link on members homepage to the key code orientation link.

Discussed during the membership committee meeting on 2/1/23. The handbook is very long, and probably what most people need to know is how to get into the DU space. The key code orientation slide deck explains how to get into the DU space more concisely.

### How is this code tested?
Locally -- screenshot below.
No unit tests needed because this is just a text change.

### Are any database migrations required by this change?
No

### Are there any configuration or environment changes needed?
No

### Screenshots please :)
![Screenshot 2023-02-01 10 04 00 PM](https://user-images.githubusercontent.com/5607966/216244634-bb8e3e22-fc6a-4ac6-9a89-3005eebfe84e.png)

I tried the new "Key code orientation" link to make sure it goes to the right place.