### PR TITLE
Bump ffi version to 1.15.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       i18n (>= 1.8.11, < 2)
     faraday (0.17.5)
       multipart-post (>= 1.2, < 3)
-    ffi (1.13.1)
+    ffi (1.15.5)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.1.0)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #791

### What does this code do, and why?
ffi 1.13.1 doesn't build on arm64.

There doesn't seem to be a specific reason to stick with that version, so upgrade to a version that does build for developers working on that architecture.

### How is this code tested?
Ran tests. Cursory check of app still appears functional.

### Are any database migrations required by this change?
None

### Are there any configuration or environment changes needed?
Updated gem version; not required immediately but nice to pick up at some future deployment
