### PR TITLE
Replace Twitter with Instagram in new member email

### DIFF
--- a/app/views/applications_mailer/confirmation.html.haml
+++ b/app/views/applications_mailer/confirmation.html.haml
@@ -7,7 +7,7 @@
     %p What happens now?
     %p
       We'd love to meet you. Please check our #{ link_to "Tumblr", "http://doubleunion.tumblr.com/" } and our
-      #{ link_to "Twitter", "https://twitter.com/doubleunionsf" } to find open events.
+      #{ link_to "Instagram", "https://www.instagram.com/doubleunionsf" } to find open events.
     %p
       Along with submitting an application, a qualification for membership is that you've met at least one member who is willing to say you seem like a reasonable potential member (such as that you'd respect the #{ link_to "base assumptions", BASE_ASSUMPTIONS_URL }, #{ link_to "anti-harassment policy", POLICIES_URL }, and responsibilities of being a member). Please come to events to meet some of us! Or if you'd prefer a quieter opportunity to meet just a couple members over a cup of tea, email #{ mail_to JOIN_EMAIL } and we'll set this up.
     %p


### PR DESCRIPTION
### What github issue is this PR for, if any?

None

### What does this code do, and why?

We aren't really using our Twitter for event announcements much anymore, so I replaced that link with Instagram (where we post announcements more often).

### How is this code tested?


### Are any database migrations required by this change?


### Are there any configuration or environment changes needed?


### Screenshots please :)
