### PR TITLE
Add note to membership coordinator re Slack

### DIFF
--- a/app/mailers/cancel_membership_mailer.rb
+++ b/app/mailers/cancel_membership_mailer.rb
@@ -8,7 +8,7 @@ class CancelMembershipMailer < ActionMailer::Base
       to: [MEMBERSHIP_EMAIL],
       cc: [user.email],
       subject: "#{user.name} is canceling their membership.",
-      body: "Please remove #{user.name} from all mailing lists."
+      body: "Please remove #{user.name} from DU mailing lists and Slack."
     )
   end
 end

--- a/spec/mailers/cancel_membership_mailer_spec.rb
+++ b/spec/mailers/cancel_membership_mailer_spec.rb
@@ -16,7 +16,7 @@ describe CancelMembershipMailer do
     end
 
     it "has the correct information" do
-      expect(mail.body).to eq "Please remove #{member.name} from all mailing lists."
+      expect(mail.body).to eq "Please remove #{member.name} from DU mailing lists and Slack."
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
None

### What does this code do, and why?
When a member cancels their membership, the membership coordinator gets an email so they know to remove the person from mailing lists. The membership coordinator also needs to remove the person from Slack by hand, so I added in a reminder about that.

### How is this code tested?
I updated the test

### Are any database migrations required by this change?
No

### Are there any configuration or environment changes needed?
No

### Screenshots please :)
