### PR TITLE
bring back member keycodes

### DIFF
--- a/app/views/members/users/index.html.haml
+++ b/app/views/members/users/index.html.haml
@@ -12,7 +12,10 @@
       = link_to "Become a voting member", edit_members_user_voting_members_path(current_user), class: "btn btn-default"
 
 %h2 Space Access
-%p Please reach out to Admins below via Email or Slack to get your own door passcode, thanks!
+- if current_user.door_code.present?
+  %p Your door code is #{current_user.door_code.code}*
+- elsif current_user.member?
+  = link_to "Become a key member", edit_members_user_key_members_path(current_user), class: "btn btn-default"
 
 = render 'bookmarks'
 

--- a/app/views/members/users/index.html.haml
+++ b/app/views/members/users/index.html.haml
@@ -13,7 +13,7 @@
 
 %h2 Space Access
 - if current_user.door_code.present?
-  %p Your door code is #{current_user.door_code.code}*
+  %p Your door code is #{current_user.door_code.code}
 - elsif current_user.member?
   = link_to "Become a key member", edit_members_user_key_members_path(current_user), class: "btn btn-default"
 

--- a/spec/features/members_home_spec.rb
+++ b/spec/features/members_home_spec.rb
@@ -5,21 +5,30 @@ describe "Members home" do
     page.set_rack_session(user_id: member.id)
   end
 
-  context "when logged in as a key member" do
+  context "when logged in as a key member with a door code" do
     let(:member) { create :key_member }
 
-    it "shows space access information" do
+    before do
+      create :door_code, code: "123456", user: member
+    end
+
+    it "shows their door code" do
       visit members_root_path
-      expect(page).to have_content "Please reach out to Admins below via Email or Slack to get your own door passcode, thanks!"
+      expect(page).to have_content "Your door code is 123456*"
     end
   end
 
   context "when logged in as a non-key-member" do
     let(:member) { create :member }
 
-    it "does not show content about unlocking the door" do
+    it "shows a button to become a key member" do
       visit members_root_path
-      expect(page).to_not have_content "unlock the door"
+      expect(page).to have_link "Become a key member"
+    end
+
+    it "does not show a door code" do
+      visit members_root_path
+      expect(page).to_not have_content "Your door code is"
     end
   end
 end

--- a/spec/features/members_home_spec.rb
+++ b/spec/features/members_home_spec.rb
@@ -14,7 +14,7 @@ describe "Members home" do
 
     it "shows their door code" do
       visit members_root_path
-      expect(page).to have_content "Your door code is 123456*"
+      expect(page).to have_content "Your door code is 123456"
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
We are back to key codes, but they don't show up on the website. Instead, administrators have been messaging people their key codes

### What does this code do, and why?
Show the member key code if they have one. Otherwise, click the "Become a Key Member" button if they don't have one after they finish the key orientation. Otherwise, if they have permission to have a key code but they do not have a key code, there's a message to email somebody for help. 

### How is this code tested?
deployed on staging -  https://du-arooo-staging-896dffc852a3.herokuapp.com/
### Are any database migrations required by this change?
no

### Are there any configuration or environment changes needed?
no - luckily, the key code was already there. We just had to expose it. 

### Screenshots please :)
